### PR TITLE
DDCNLS-1069: Changed MA content for new tax year "You can backdate your claim to include any tax year since 5 April 2015 that you were eligible for Marriage Allowance."

### DIFF
--- a/app/views/multiyear/pta/how_it_works.scala.html
+++ b/app/views/multiyear/pta/how_it_works.scala.html
@@ -44,7 +44,7 @@
         @Html(Messages("pages.how-it-works.lede-pre4", NumberFormat.getIntegerInstance().format(ApplicationConfig.PERSONAL_ALLOWANCE)))
     </p>
     <div class="application-notice info-notice">
-    	<p class="lede">@Html(Messages("pages.how-it-works.lede-pre5", (TaxYearResolver.currentTaxYear-1).toString(), TaxYearResolver.currentTaxYear.toString(), TextGenerators.ukDateTransformer(Some(TaxYearResolver.startOfTaxYear(TaxYearResolver.currentTaxYear-1)), LanguageUtils.isWelsh(lang))))</p>
+    	<p class="lede">@Html(Messages("pages.how-it-works.lede-pre5"))</p>
     </div>
     <h4 class="heading-medium">@Html(Messages("pages.how-it-works.apply.heading"))</h4>
     <p class="lede">@Html(Messages("pages.how-it-works.detail"))</p>

--- a/conf/messages
+++ b/conf/messages
@@ -10,30 +10,30 @@
 #███████████████████████████████████████████████████████████████████████████████████████████████████
 
 pages.form.field.description.transferor-income=Confirm your annual income
-pages.form.field.description.recipient-income=Confirm your spouse or civil partner''s annual income
+pages.form.field.description.recipient-income=Confirm your spouse or civil partner’s annual income
 
-pages.form.field.description.name=Confirm your spouse or civil partner''s first name
-pages.form.field.name.error.error.required=Tell us your spouse or civil partner''s first name.
+pages.form.field.description.name=Confirm your spouse or civil partner’s first name
+pages.form.field.name.error.error.required=Tell us your spouse or civil partner’s first name.
 pages.form.field.name.error.error.pattern=Use letters only.
 pages.form.field.name.error.error.maxLength=Use up to or no more than {0} letters.
 
-pages.form.field.description.last-name=Confirm your spouse or civil partner''s last name
-pages.form.field.last-name.error.error.required=Tell us your spouse or civil partner''s last name.
+pages.form.field.description.last-name=Confirm your spouse or civil partner’s last name
+pages.form.field.last-name.error.error.required=Tell us your spouse or civil partner’s last name.
 pages.form.field.last-name.error.error.pattern=Use letters only.
 pages.form.field.last-name.error.error.maxLength=Use up to or no more than {0} letters.
 
-pages.form.field.description.gender=Confirm your spouse or civil partner''s gender
-pages.form.field.gender.error.error.required=Tell us your spouse or civil partner''s gender.
-pages.form.field.gender.error.error.invalid=Tell us your spouse or civil partner''s gender.
+pages.form.field.description.gender=Confirm your spouse or civil partner’s gender
+pages.form.field.gender.error.error.required=Tell us your spouse or civil partner’s gender.
+pages.form.field.gender.error.error.invalid=Tell us your spouse or civil partner’s gender.
 pages.form.field.dom.error.required=Tell us your date of marriage.
 pages.form.field.dod.error.required=Tell us your date of divorce.
 pages.form.field.dom.error.min-date=This date is too far in the past.
 pages.form.field.dom.error.max-date=This date is in the future.
 
-pages.form.field.description.nino=Confirm your spouse or civil partner''s National Insurance number
-pages.form.field.nino.error.error.required=Tell us your spouse or civil partner''s National Insurance number.
+pages.form.field.description.nino=Confirm your spouse or civil partner’s National Insurance number
+pages.form.field.nino.error.error.required=Tell us your spouse or civil partner’s National Insurance number.
 pages.form.field.nino.error.error.invalid=Check their National Insurance number and enter it correctly.
-pages.form.field.nino.error.self=You can''t enter your own details.
+pages.form.field.nino.error.self=You can’t enter your own details.
 
 pages.form.field.description.dateOfMarriage=Confirm your date of marriage
 pages.form.field.description-alt.dateOfDivorce=Confirm your date of divorce
@@ -55,32 +55,32 @@ pages.form.field-required.multiyear-transferor-income-criteria=Tell us if your a
 
 pages.form.field-required.lower-earner=Tell us if you are the lower earner in the relationship.
 
-pages.form.field-required.applyForCurrentYear=Tell us whether you''d like to apply for this current tax year.
-pages.form.field-required.applyForHistoricYears=Tell us whether you''d like to apply for earlier tax years.
+pages.form.field-required.applyForCurrentYear=Tell us whether you’d like to apply for this current tax year.
+pages.form.field-required.applyForHistoricYears=Tell us whether you’d like to apply for earlier tax years.
 
-pages.form.field.description.applyForCurrentYear=Confirm whether you''d like to apply for this current tax year
-pages.form.field.description.applyForHistoricYears=Confirm whether you''d like to apply for earlier tax years
+pages.form.field.description.applyForCurrentYear=Confirm whether you’d like to apply for this current tax year
+pages.form.field.description.applyForHistoricYears=Confirm whether you’d like to apply for earlier tax years
 
-pages.form.extra-year.field-required=Tell us whether you''d like to apply for the previous {0} to {1} tax year.
-pages.form.field.description.year-2015-=Confirm whether you''d like to apply for the previous 2015 to 2016 tax year
-pages.form.field.description.year-2016-=Confirm whether you''d like to apply for the previous 2016 to 2017 tax year
-pages.form.field.description.year-2017-=Confirm whether you''d like to apply for the previous 2017 to 2018 tax year
-pages.form.field.description.year-2018-=Confirm whether you''d like to apply for the previous 2018 to 2019 tax year
-pages.form.field.description.year-2019-=Confirm whether you''d like to apply for the previous 2019 to 2020 tax year
-pages.form.field.description.year-2020-=Confirm whether you''d like to apply for the previous 2020 to 2021 tax year
-pages.form.field.description.year-2021-=Confirm whether you''d like to apply for the previous 2021 to 2022 tax year
-pages.form.field.description.year-2022-=Confirm whether you''d like to apply for the previous 2022 to 2023 tax year
-pages.form.field.description.year-2023-=Confirm whether you''d like to apply for the previous 2023 to 2024 tax year
-pages.form.field.description.year-2024-=Confirm whether you''d like to apply for the previous 2024 to 2025 tax year
-pages.form.field.description.year-2025-=Confirm whether you''d like to apply for the previous 2025 to 2026 tax year
-pages.form.field.description.year-2026-=Confirm whether you''d like to apply for the previous 2026 to 2027 tax year
+pages.form.extra-year.field-required=Tell us whether you’d like to apply for the previous {0} to {1} tax year.
+pages.form.field.description.year-2015-=Confirm whether you’d like to apply for the previous 2015 to 2016 tax year
+pages.form.field.description.year-2016-=Confirm whether you’d like to apply for the previous 2016 to 2017 tax year
+pages.form.field.description.year-2017-=Confirm whether you’d like to apply for the previous 2017 to 2018 tax year
+pages.form.field.description.year-2018-=Confirm whether you’d like to apply for the previous 2018 to 2019 tax year
+pages.form.field.description.year-2019-=Confirm whether you’d like to apply for the previous 2019 to 2020 tax year
+pages.form.field.description.year-2020-=Confirm whether you’d like to apply for the previous 2020 to 2021 tax year
+pages.form.field.description.year-2021-=Confirm whether you’d like to apply for the previous 2021 to 2022 tax year
+pages.form.field.description.year-2022-=Confirm whether you’d like to apply for the previous 2022 to 2023 tax year
+pages.form.field.description.year-2023-=Confirm whether you’d like to apply for the previous 2023 to 2024 tax year
+pages.form.field.description.year-2024-=Confirm whether you’d like to apply for the previous 2024 to 2025 tax year
+pages.form.field.description.year-2025-=Confirm whether you’d like to apply for the previous 2025 to 2026 tax year
+pages.form.field.description.year-2026-=Confirm whether you’d like to apply for the previous 2026 to 2027 tax year
 
 pages.form.field.transferor-income.error.field-required=Tell us your annual income.
 pages.form.field.transferor-income.error.field-invalid=Use numbers only.
 
-eligibility.feedback.incorrect-role=Check the numbers you''ve entered. Please enter the lower earner''s income followed by the higher earner''s income.
+eligibility.feedback.incorrect-role=Check the numbers you’ve entered. Please enter the lower earner’s income followed by the higher earner’s income.
 
-pages.form.field.recipient-income.error.field-required=Tell us your spouse or civil partner''s annual income.
+pages.form.field.recipient-income.error.field-required=Tell us your spouse or civil partner’s annual income.
 pages.form.field.recipient-income.error.field-invalid=Use numbers only.
 
 change.status.reason-CANCEL=I want to stop Marriage Allowance payments
@@ -100,7 +100,7 @@ pages.form.field.description-alt.endReason=Select an answer for keeping your Mar
 
 coc.end-reason.DEATH=Bereavement
 coc.end-reason.DIVORCE=Divorce or end of civil partnership
-coc.end-reason.INELIGIBLE_PARTICIPANT=Claiming Married Couple''s Allowance
+coc.end-reason.INELIGIBLE_PARTICIPANT=Claiming Married Couple’s Allowance
 coc.end-reason.INVALID_PARTICIPANT=Higher earner not eligible for Marriage Allowance
 coc.end-reason.CANCELLED=Allowance cancelled
 coc.end-reason.REJECTED=Allowance cancelled
@@ -158,7 +158,7 @@ title.dateOfBirth=Your date of birth
 title.eligible-years=Apply for the current tax year
 title.extra-years=Apply for earlier tax years
 title.transfer-in-place=Transfer in place
-title.transfer=Your partner''s details
+title.transfer=Your partner’s details
 title.finished=Application confirmed
 title.confirm-email=Confirm your email address
 title.non-eligible=You are not eligible in the current tax year
@@ -203,9 +203,9 @@ hmrc.contact-details-9=<a href="https://www.gov.uk/call-charges"> Find out about
 
 #Eligibility Calculator
 pages.calc.header=Marriage Allowance calculator
-pages.calc.para1=As a couple, find out how much tax you''d save if you applied for Marriage Allowance in this tax year.
-pages.form.field.income=Lower earner''s yearly pre-tax income 
-pages.form.field.recipient-income=Higher earner''s yearly pre-tax income
+pages.calc.para1=As a couple, find out how much tax you’d save if you applied for Marriage Allowance in this tax year.
+pages.form.field.income=Lower earner’s yearly pre-tax income
+pages.form.field.recipient-income=Higher earner’s yearly pre-tax income
 pages.calc.field-helper.income=This is your income figure before any tax is deducted.
 pages.calc.field-helper.partners-income=This is their income figure before any tax is deducted.
 pages.calc.how-to-apply=How to apply
@@ -226,8 +226,8 @@ pages.form.field.description.selectedYear=You need to select an answer
 ############################
 eligibility.feedback.transferor-not-eligible-2016=You are not eligible for Marriage Allowance. As the person making the transfer, your income must be below £43,000.
 eligibility.feedback.transferor-not-eligible-2017=You are not eligible for Marriage Allowance. As the person making the transfer, your income must be below £45,000.
-eligibility.feedback.recipient-not-eligible-2016=You are not eligible for Marriage Allowance. Your spouse or civil partner''s annual income must be between £11,001 and £43,000.
-eligibility.feedback.recipient-not-eligible-2017=You are not eligible for Marriage Allowance. Your spouse or civil partner''s annual income must be between £11,501 and £45,000.
+eligibility.feedback.recipient-not-eligible-2016=You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,001 and £43,000.
+eligibility.feedback.recipient-not-eligible-2017=You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000.
 eligibility.check.unlike-benefit-as-couple-2016=You are eligible for Marriage Allowance, but you are unlikely to benefit as a couple because your income is over £11,000.
 eligibility.check.unlike-benefit-as-couple-2017=You are eligible for Marriage Allowance, but you are unlikely to benefit as a couple because your income is over £11,500.
 max-benefit-2014=£212
@@ -243,7 +243,7 @@ income-between-2017={0} income was between £11,501 and £45,000
 
 #Confirmation Message
 pages.confirm.html.h1=Check your details and confirm the application
-pages.confirm.html.check-details=Check the details you''ve entered and confirm that this is the person you are married to or in a civil partnership with. You can then apply to transfer £1,050 of your Personal Allowance to them.
+pages.confirm.html.check-details=Check the details you’ve entered and confirm that this is the person you are married to or in a civil partnership with. You can then apply to transfer £1,050 of your Personal Allowance to them.
 
 #Eligibility Check
 eligibility.check.header=Your eligibility
@@ -253,47 +253,47 @@ eligibility.check.span.para=To apply for Marriage Allowance, you must be married
 eligibility.check.married=Does this apply to you?
 eligibility.check.married.legend=Are you married or in a legally registered civil partnership?
 eligibility.check.yes = Yes
-eligibility.check.married.error=You aren''t eligible for Marriage Allowance because you aren''t married or in a legally registered civil partnership.
+eligibility.check.married.error=You aren’t eligible for Marriage Allowance because you aren’t married or in a legally registered civil partnership.
 multiyear.check.income=Since 6 April 2015 was your annual income at or below the Personal Allowance level?
-eligibility.check.non-eligible=Based on your answers, you aren''t eligible for Marriage Allowance.
+eligibility.check.non-eligible=Based on your answers, you aren’t eligible for Marriage Allowance.
 eligibility.check.lower.earner.information1=To benefit from Marriage Allowance, you must be the lower earner in the relationship and earn £{0} or less a year.
 eligibility.check.lower.earner.information2=This is your income figure before any tax is deducted.
 eligibility.check.lower.earner.h1=Your income
 eligibility.check.lower.earner.question=Does this apply to you?
-eligibility.check.lower.earner.error=You might not benefit from Marriage Allowance in this tax year because your income is above £{0}. You can still continue to check whether you''ll benefit for previous years if your income was lower in the past.
-eligibility.check.partners.income.h1=Your partner''s income
+eligibility.check.lower.earner.error=You might not benefit from Marriage Allowance in this tax year because your income is above £{0}. You can still continue to check whether you’ll benefit for previous years if your income was lower in the past.
+eligibility.check.partners.income.h1=Your partner’s income
 eligibility.check.partners.income.information1=To be eligible for Marriage Allowance, your partner must earn between £{0} and £{1} a year.
 eligibility.check.partners.income.information2=This is their income figure before any tax is deducted.
 eligibility.check.partners.income.h2=Does this apply to your partner?
 eligibility.check.partners.income.before.tax=This is their income figure before any tax is deducted.
-eligibility.check.partners.income.error=You''re not eligible for Marriage Allowance in this tax year because your partner''s income is too high or too low. You can still continue to check your eligibility for previous years.
-eligibility.check.date.of.birth.h1=You and your partner''s date of birth
+eligibility.check.partners.income.error=You’re not eligible for Marriage Allowance in this tax year because your partner’s income is too high or too low. You can still continue to check your eligibility for previous years.
+eligibility.check.date.of.birth.h1=You and your partner’s date of birth
 eligibility.check.date.of.birth.span.para=To benefit from Marriage Allowance, you and your partner should be born on or after 6 April 1935.
 eligibility.check.date.of.birth.span.married=Does this apply to you and your partner?
-eligibility.check.date.of.birth.error=If you or your partner were born before 6 April 1935, you might benefit more as a couple if you apply for <a href="https://www.gov.uk/married-couples-allowance" data-journey-click="marriage-allowance:outboundlink:married_couples-link" target="_blank">Married Couple’s Allowance</a>.<p></p>You can still choose to continue and apply for Marriage Allowance instead. But you cannot receive both Marriage Allowance and Married Couple''s Allowance at the same time.
+eligibility.check.date.of.birth.error=If you or your partner were born before 6 April 1935, you might benefit more as a couple if you apply for <a href="https://www.gov.uk/married-couples-allowance" data-journey-click="marriage-allowance:outboundlink:married_couples-link" target="_blank">Married Couple’s Allowance</a>.<p></p>You can still choose to continue and apply for Marriage Allowance instead. But you cannot receive both Marriage Allowance and Married Couple’s Allowance at the same time.
 
 #Verify
 pages.verify_triage.header=Identity check
 pages.verify_triage.para1=Before you continue, we need to check who you are.
-pages.verify_triage.para2= You''ll now be asked some questions relating to information held on you by HMRC.
+pages.verify_triage.para2= You’ll now be asked some questions relating to information held on you by HMRC.
 
 #Finished Message
 pages.finished.successful=Marriage Allowance application successful
 pages.finished.para1.email1=An email with full details acknowledging your application will be sent to you at {0}
 pages.finished.para1.email2=from noreply@tax.service.gov.uk within 24 hours.
-pages.finished.para2=If it doesn''t appear in your inbox, please check your spam or junk folder.
+pages.finished.para2=If it doesn’t appear in your inbox, please check your spam or junk folder.
 pages.finished.now=What happens next
-pages.finished.para4=HMRC will now process your Marriage Allowance application. Please check the email we''ve sent you for full details on how you''ll receive Marriage Allowance.
-pages.finished.para5=If they''re employed and pay tax via PAYE, we''ll send them a revised notice of tax coding by post. We''ll also tell their employer to start using the new tax code.
+pages.finished.para4=HMRC will now process your Marriage Allowance application. Please check the email we’ve sent you for full details on how you’ll receive Marriage Allowance.
+pages.finished.para5=If they’re employed and pay tax via PAYE, we’ll send them a revised notice of tax coding by post. We’ll also tell their employer to start using the new tax code.
 pages.finished.para6=Your revised notice of tax coding will show in your personal tax account within 24 hours.
 pages.finished.para7=There is no need to contact us.
 pages.finished.back-pta=Back to Personal Tax Account
 pages.finished.check-link-para=You can <a id="pta-link" href="{0}" data-journey-click="marriage-allowance:outboundlink:ptaclick_finish" >check your current Marriage Allowance and make changes</a> at any time through your personal tax account.
 
 #Registration page - Your spouse details
-pages.form.h1=Your spouse or civil partner''s details
+pages.form.h1=Your spouse or civil partner’s details
 pages.form.details=As the lower earner you <span id="transferor-name">{0}</span> can now apply to help your partner reduce the amount of tax they pay.
-pages.form.enter-data=Enter your spouse or civil partner''s details:
+pages.form.enter-data=Enter your spouse or civil partner’s details:
 pages.form.field.name=What is their first name?
 pages.form.field.last-name=What is their last name?
 pages.form.field.gender=What is their gender?
@@ -307,10 +307,10 @@ pages.form.field-helper.nino-found=This can be found on their National Insurance
 pages.form.field-helper.dom=For example, 31 3 1980
 pages.form.field-helper.dod=For example, 31 3 1980
 pages.form.field.your-confirmation=Confirmation email
-pages.form.field.yourDetails=We''ll email confirmation of your Marriage Allowance application within 24 hours. We won''t share your email with anyone else.
+pages.form.field.yourDetails=We’ll email confirmation of your Marriage Allowance application within 24 hours. We won’t share your email with anyone else.
 pages.form.field.transferor-email=Your email address
 pages.form.field.enter-email=Enter email address
-pages.form.field.dod=If you''re currently separated, you can still receive Marriage Allowance until you legally end your marriage or civil partnership.
+pages.form.field.dod=If you’re currently separated, you can still receive Marriage Allowance until you legally end your marriage or civil partnership.
 pages.form.field.dod.question=When did you legally end your marriage or civil partnership?
 
 #Date of Marriage
@@ -324,13 +324,13 @@ pages.how-it-works.heading=How It Works
 pages.how-it-works.lede-pre1=<a href="https://www.gov.uk/marriage-allowance-guide">Marriage Allowance</a> lets you transfer £{0} of your Personal Allowance to your husband, wife or civil partner.
 pages.how-it-works.lede-pre2=This can reduce their tax by up to £{0} this tax year (6 April to 5 April the next year). 
 pages.how-it-works.lede-pre4=To benefit as a couple, you need to earn less than your partner and have an income of £{0} or less. 
-pages.how-it-works.lede-pre5=If you were eligible for Marriage Allowance in the  {0} to {1} tax year, you can backdate your claim to {2} and reduce the tax paid by up to £432.
+pages.how-it-works.lede-pre5=You can backdate your claim to include any tax year since 5 April 2015 that you were eligible for Marriage Allowance.
 pages.how-it-works.lede-in=Personal Allowance
 pages.how-it-works.lede-post=to your spouse or civil partner.
-pages.how-it-works.tse=to see if you''re eligible for Marriage Allowance
+pages.how-it-works.tse=to see if you’re eligible for Marriage Allowance
 pages.how-it-works.apply.heading=Before you apply
-pages.how-it-works.email=You''ll get an email confirming your application.
-pages.how-it-works.detail=You need you and your partner''s National Insurance numbers.
+pages.how-it-works.email=You’ll get an email confirming your application.
+pages.how-it-works.detail=You need you and your partner’s National Insurance numbers.
 
 #Change of Circumstances
 change.status.button=Cancel Marriage Allowance
@@ -343,19 +343,19 @@ change.status.transferor.list=<li>have divorced or ended your civil partnership<
 change.status.receiver.list=<li>have divorced or ended your civil partnership</li><li>have had a change in your income</li><li>want to reject the allowance</li><li>have suffered a bereavement</li>
 change.status.reason-for=Reason for change
 change.status.reason-for-divorce=Do you want to keep your Marriage Allowance in place until {0}?
-change.status.confirm.info=We''ll email confirmation that you''ve cancelled your Marriage Allowance within 24 hours.
-change.status.confirm.more.info=We won''t share your email with anyone else.
+change.status.confirm.info=We’ll email confirmation that you’ve cancelled your Marriage Allowance within 24 hours.
+change.status.confirm.more.info=We won’t share your email with anyone else.
 change.status.confirm-cancellation.button=Confirm cancellation
-change.status.confirm.field.your-email=We''ll send you confirmation of your cancellation.
+change.status.confirm.field.your-email=We’ll send you confirmation of your cancellation.
 change.status.confirm.field.your-name=Your name
 change.status.earnings.h1=Change of income
-change.status.earnings.h2=You need to tell us if your or your partner''s income changes so we can tell you if:
+change.status.earnings.h2=You need to tell us if your or your partner’s income changes so we can tell you if:
 change.status.earnings.tr.instruction-1=claiming Marriage Allowance will still benefit you as a couple
 change.status.earnings.tr.instruction-2=you need to cancel your Marriage Allowance
-change.status.earnings.rec.instruction-1=you expect your income over the whole tax year to be more than £{0}, because you''ll no longer be eligible as a couple in this tax year
+change.status.earnings.rec.instruction-1=you expect your income over the whole tax year to be more than £{0}, because you’ll no longer be eligible as a couple in this tax year
 change.status.earnings.rec.instruction-2=your partner expects their income over the whole tax year to be more than £{0}, because you might not benefit from Marriage Allowance as a couple
 change.status.divorce.date.invalid.h1=There is a problem with the dates you entered
-change.status.divorce.date.invalid.para1=The date you divorced or dissolved your civil partnership can''t be before the date you started claiming marriage allowance.
+change.status.divorce.date.invalid.para1=The date you divorced or dissolved your civil partnership can’t be before the date you started claiming marriage allowance.
 change.status.divorce.date.invalid.para2=You can go back and check the information you've entered is correct.
 change.status.divorce.date.invalid.para3=Contact HMRC if you think we have the wrong date for the start of your marriage or civil partnership.
 change.status.divorce.h1=Date of divorce or end of civil partnership
@@ -365,34 +365,34 @@ change.status.divorce-py-content=This will be removed from the beginning of the 
 change.status.divorce.transferor.directions=If you cancel Marriage Allowance, you can choose either to keep it in place until {0} (the end of the current tax year) or to stop it from {1} (the start of the current tax year).
 change.status.divorce.transferor.h1=Cancelling Marriage Allowance due to divorce or the end of a civil partnership
 change.status.divorce.transferor.conditional1.h1=Cancelling Marriage Allowance due to divorce or the end of a civil partnership
-change.status.divorce.transferor.conditional1.para1=You''ve told us you divorced or ended your civil partnership on {0}.
+change.status.divorce.transferor.conditional1.para1=You’ve told us you divorced or ended your civil partnership on {0}.
 change.status.divorce.transferor.conditional1.para2=As this date falls within the previous tax year:
 change.status.divorce.transferor.conditional1.para3=your Allowance will remain in place until {0}, the end of the tax year you got divorced
-change.status.divorce.transferor.conditional1.para4=if your ex-partner has not paid enough tax, we''ll collect it by adjusting their tax code
+change.status.divorce.transferor.conditional1.para4=if your ex-partner has not paid enough tax, we’ll collect it by adjusting their tax code
 change.status.divorce.transferor.conditional2.para2=You can keep Marriage Allowance until {0}, the end of the tax year you divorced. Your Personal Allowance will return to normal from {1}, the start of the next tax year.
-change.status.divorce.transferor.conditional2.para3=We''ll let you know if you''ve paid the right amount of tax at the end of the tax year. If you''ve not paid enough, we''ll collect it by adjusting your tax code.
+change.status.divorce.transferor.conditional2.para3=We’ll let you know if you’ve paid the right amount of tax at the end of the tax year. If you’ve not paid enough, we’ll collect it by adjusting your tax code.
 change.status.divorce.transferor.option1=If you choose to keep it in place until {0}, your ex-partner will not have to pay back any tax.
-change.status.divorce.transferor.option2=If you choose to stop it from {0}, your ex-partner may not have paid enough tax and will have to pay it back. We''ll collect any tax they owe by adjusting their tax code.
+change.status.divorce.transferor.option2=If you choose to stop it from {0}, your ex-partner may not have paid enough tax and will have to pay it back. We’ll collect any tax they owe by adjusting their tax code.
 change.status.divorce.transferor.keep=Would you like to keep Marriage Allowance until the end of the tax year?
 change.status.divorce.transferor.eoy-yes=Your Marriage Allowance will remain until the end of this tax year ({0}). Your Personal Allowance will be adjusted at the start of the new tax year on {1}.
 change.status.divorce.transferor.eoy-no=Your Marriage Allowance will stop from {0}.<br><p>This could result in your ex-partner having to pay back any tax they owe.</p>
 change.status.divorce.recipient.para1=your Marriage Allowance will be cancelled from {0}, the end of the current tax year
 change.status.divorce.recipient.previous.para1=your Marriage Allowance will be cancelled from {0}
-change.status.divorce.recipient.previous.para2=if you haven''t paid enough tax, we''ll usually collect it by adjusting your tax code
+change.status.divorce.recipient.previous.para2=if you haven’t paid enough tax, we’ll usually collect it by adjusting your tax code
 change.status.divorce.recipient.content1=As this date falls within the current tax year:
-change.status.divorce.recipient.options=Once you''ve told us, Marriage Allowance will remain in place until the end of the tax year ({0}). HMRC won''t ask you to pay back this extra allowance.
-change.status.divorce.recipient.directions=You should tell us if you''ve divorced and have a <a href="{0}">decree absolute</a>, or if your civil partnership has ended and you have a <a href="{1}">final order</a>. These are the documents that legally end your marriage or civil partnership.
-change.status.historic-active.result=Removing Marriage Allowance from the start of the tax year could result in your partner underpaying tax. We''ll notify them at the end of the tax year. Any underpayment will usually be collected through an adjustment to their tax code.
-change.status.historic-active.directions=You can remove Marriage Allowance from the start of the tax year ({2}) if you''ve divorced and have a <a href="{0}">decree absolute</a>, or if your civil partnership has ended and you have a <a href="{1}">final order</a>. These are the documents that legally end your marriage or civil partnership.
+change.status.divorce.recipient.options=Once you’ve told us, Marriage Allowance will remain in place until the end of the tax year ({0}). HMRC won’t ask you to pay back this extra allowance.
+change.status.divorce.recipient.directions=You should tell us if you’ve divorced and have a <a href="{0}">decree absolute</a>, or if your civil partnership has ended and you have a <a href="{1}">final order</a>. These are the documents that legally end your marriage or civil partnership.
+change.status.historic-active.result=Removing Marriage Allowance from the start of the tax year could result in your partner underpaying tax. We’ll notify them at the end of the tax year. Any underpayment will usually be collected through an adjustment to their tax code.
+change.status.historic-active.directions=You can remove Marriage Allowance from the start of the tax year ({2}) if you’ve divorced and have a <a href="{0}">decree absolute</a>, or if your civil partnership has ended and you have a <a href="{1}">final order</a>. These are the documents that legally end your marriage or civil partnership.
 change.status.cancel.h1=Cancelling Marriage Allowance
 
-change.status.cancel.content=We''ll cancel your Marriage Allowance, but it will remain in place until {0}, the end of the current tax year.
+change.status.cancel.content=We’ll cancel your Marriage Allowance, but it will remain in place until {0}, the end of the current tax year.
 change.status.cancel.content1=Your Personal Allowance will go back to the previous amount from {0}, the start of the new tax year. Your partner will not have to pay back any tax.
 change.status.reject.h1=Remove a previous Marriage Allowance claim
 change.status.reject.content=Your Marriage Allowance will be cancelled from {0}, the start of the tax year you first received it.
-change.status.reject.warning=This could result in you not paying enough tax. We''ll let you know if you''ve paid the right amount of tax at the end of the tax year. If you haven''t paid enough, we''ll usually collect it by adjusting your tax code.
+change.status.reject.warning=This could result in you not paying enough tax. We’ll let you know if you’ve paid the right amount of tax at the end of the tax year. If you haven’t paid enough, we’ll usually collect it by adjusting your tax code.
 change.status.reject.previous.content=You can remove the Marriage Allowance you claimed previously. The allowance will be removed from {0}, the start of the tax year you first received it.
-change.status.reject.previous.warning=This could result in you underpaying tax. We''ll let you know if you''ve paid the right amount of tax at the end of the tax year. Any underpayment will usually be collected through an adjustment to your tax code.
+change.status.reject.previous.warning=This could result in you underpaying tax. We’ll let you know if you’ve paid the right amount of tax at the end of the tax year. Any underpayment will usually be collected through an adjustment to your tax code.
 change.status.allowance=Allowance status
 change.status.realtionship-end=Reason for cancellation
 change.status.confirm-removal.button=Confirm removal
@@ -411,8 +411,8 @@ change.status.history.reason=Status
 change.status.active=Active
 change.status.active.present.year=to Present
 change.status.active.to=to
-change.status.transferor.amount=You''ll stop transferring Marriage Allowance to your spouse or civil partner at end of the tax year ({0}).
-change.status.receiving.amount=You''ll stop receiving Marriage Allowance from your spouse or civil partner at end of the tax year ({0}).
+change.status.transferor.amount=You’ll stop transferring Marriage Allowance to your spouse or civil partner at end of the tax year ({0}).
+change.status.receiving.amount=You’ll stop receiving Marriage Allowance from your spouse or civil partner at end of the tax year ({0}).
 change.status.transferor.stop-sooner=You can end your Marriage Allowance transfer sooner.
 change.status.recipient.stop-sooner=You can stop receiving Marriage Allowance sooner.
 change.status.finish.divorce=Divorce successful
@@ -421,13 +421,13 @@ change.status.finish.will-be-current=Your Marriage Allowance will be removed at 
 change.status.finish.will-be-next=Your Marriage Allowance will be removed from the start of the current tax year.
 change.status.apply=Apply for Marriage Allowance
 change.status.have-not-applied=You are not currently benefiting from Marriage Allowance.
-change.status.ask-to-check=If you are married or in a civil partnership you may be able to transfer some of your tax-free Personal Allowance to your partner. Check if you''re eligible to apply for Marriage Allowance.
-change.status.bereavement.sorry=We''re sorry for your loss
+change.status.ask-to-check=If you are married or in a civil partnership you may be able to transfer some of your tax-free Personal Allowance to your partner. Check if you’re eligible to apply for Marriage Allowance.
+change.status.bereavement.sorry=We’re sorry for your loss
 change.status.bereavement.notify-hmrc=You can let HMRC know of a bereavement on:
 change.status.bereavement.rec.instruction=If your partner transferred some of their Personal Allowance to you before they died:
 change.status.bereavement.rec.instruction-1=your Personal Allowance will remain at the higher level until the end of the tax year (5 April)
 change.status.bereavement.rec.instruction-2=their estate will be treated as having a smaller Personal Allowance, because they transferred some of it to you
-change.status.bereavement.tr.instruction=If your partner dies after you''ve transferred some of your Personal Allowance to them:
+change.status.bereavement.tr.instruction=If your partner dies after you’ve transferred some of your Personal Allowance to them:
 change.status.bereavement.tr.instruction-1=their estate will be treated as having the extra Personal Allowance you transferred to them
 change.status.bereavement.tr.instruction-2=your Personal Allowance will go back to the normal amount at the end of the tax year (5 April)
 change.status.divorce.radio=Divorce or end of civil partnership
@@ -435,29 +435,29 @@ change.status.bereavement.radio=Bereavement
 change.status.earnings.radio=Change in your income
 change.status.cancel.radio=I want to stop Marriage Allowance payments
 change.status.confirm-change=Confirm you want to change this Marriage Allowance transfer.
-change.status.previous-years=We''ve noticed you might be able to claim Marriage Allowance for previous tax years. If you''re eligible we''ll backdate it and send your partner a cheque in the post.
+change.status.previous-years=We’ve noticed you might be able to claim Marriage Allowance for previous tax years. If you’re eligible we’ll backdate it and send your partner a cheque in the post.
 confirm.transferor.heading=Confirm cancellation of Marriage Allowance
 confirm.recipient.ended.reject.heading=Confirm removal of a previous Marriage Allowance claim
-pages.ended.reject.message=You''ve asked us to remove your Marriage Allowance from tax year {0}. This means:
+pages.ended.reject.message=You’ve asked us to remove your Marriage Allowance from tax year {0}. This means:
 pages.ended.reject.message1=your Marriage Allowance will be removed from {0}, the start of the tax year you first received it
-pages.ended.reject.message2=if you haven''t paid enough tax, we''ll usually collect it by adjusting your tax code
-pages.confirm.message=You''ve asked us to cancel your Marriage Allowance. This means:
+pages.ended.reject.message2=if you haven’t paid enough tax, we’ll usually collect it by adjusting your tax code
+pages.confirm.message=You’ve asked us to cancel your Marriage Allowance. This means:
 pages.confirm.message1=your Marriage Allowance will remain in place until {0}, the end of the current tax year
 pages.confirm.message2=your Personal Allowance will go back to the normal amount from {0}, the start of the new tax year
 pages.reject.message1=your Marriage Allowance will be cancelled from {0}, the start of the tax year you first received it
-pages.reject.message2=we''ll let you know if you''ve paid the right amount of tax at the end of tax year
-pages.reject.message3=if you haven''t paid enough tax, we''ll usually collect it by adjusting your tax code
+pages.reject.message2=we’ll let you know if you’ve paid the right amount of tax at the end of tax year
+pages.reject.message3=if you haven’t paid enough tax, we’ll usually collect it by adjusting your tax code
 confirm.cancellation.button=Confirm cancellation
-pages.confirm.divorce.cy.message=You''ve asked us to keep Marriage Allowance in place until {0}, the end of the current tax year. This means:
+pages.confirm.divorce.cy.message=You’ve asked us to keep Marriage Allowance in place until {0}, the end of the current tax year. This means:
 pages.confirm.divorce.cy.message1=your Personal Allowance will go back to the normal amount from {0}, the start of the new tax year
-pages.confirm.divorce.cy.prev.message=You''ve asked us to cancel your Marriage Allowance. This means:
+pages.confirm.divorce.cy.prev.message=You’ve asked us to cancel your Marriage Allowance. This means:
 pages.confirm.divorce.cy.prev.message1=your Allowance will remain in place until {0}, the end of the tax year you got divorced
-pages.confirm.divorce.cy.prev.message2=if your ex-partner has not paid enough tax, we''ll collect it by adjusting their tax code
-pages.confirm.divorce.py.message=You''ve asked us to cancel your Marriage Allowance from {0}, the start of the current tax year. This means:
-pages.confirm.divorce.py.message1=if your ex-partner has not paid enough tax, we''ll collect it by adjusting their tax code
+pages.confirm.divorce.cy.prev.message2=if your ex-partner has not paid enough tax, we’ll collect it by adjusting their tax code
+pages.confirm.divorce.py.message=You’ve asked us to cancel your Marriage Allowance from {0}, the start of the current tax year. This means:
+pages.confirm.divorce.py.message1=if your ex-partner has not paid enough tax, we’ll collect it by adjusting their tax code
 pages.confirm.divorce.py.message2=your Personal Allowance will go back to the normal amount from {0}, the start of the current tax year
 pages.confirm.recipient.divorce.cy.prev.message1=your Marriage Allowance will be cancelled from {0}, the end of the tax year you divorced
-pages.confirm.recipient.divorce.cy.prev.message2=if you haven''t paid enough tax, we''ll usually collect it by adjusting your tax code
+pages.confirm.recipient.divorce.cy.prev.message2=if you haven’t paid enough tax, we’ll usually collect it by adjusting your tax code
 pages.confirm.recipient.divorce.cy.message1=your Marriage Allowance will remain in place until {0}, the end of the current tax year
 pages.confirm.recipient.divorce.cy.message2=your Personal Allowance will go back to the normal amount from {0}, the start of the new tax year
 
@@ -472,20 +472,20 @@ transferor.not.found=We were unable to find a HMRC record for you.
 recipient.not.found.para1=We were unable to find a HMRC record of your spouse or civil partner.
 recipient.not.found.para2=Check with them and confirm the details you supplied.
 transferor.no-eligible-years=We were unable to process your Marriage Allowance application.
-transferor.no-previous-years-available=Based on the date of marriage or civil partnership you''ve provided, you''re not eligible for Marriage Allowance.
+transferor.no-previous-years-available=Based on the date of marriage or civil partnership you’ve provided, you’re not eligible for Marriage Allowance.
 recipient.has.relationship.para1=We were unable to process your application.
 recipient.has.relationship.para2=Check with your spouse or civil partner and confirm the details you supplied.
 session.timeout.button=Start again
 session.timeout.statement=Your session has timed out
-session.timeout.verbose-statement=You''ve been signed out of Marriage Allowance.
+session.timeout.verbose-statement=You’ve been signed out of Marriage Allowance.
 create.relationship.failure=Cannot create relationship
-not.authorised=Sorry, you haven''t been authorised to proceed.
-technical.issue.para1=We''re experiencing technical difficulties
-technical.issue.para2=We''re having difficulties with the service, try again in a few minutes.
+not.authorised=Sorry, you haven’t been authorised to proceed.
+technical.issue.para1=We’re experiencing technical difficulties
+technical.issue.para2=We’re having difficulties with the service, try again in a few minutes.
 technical.issue.back=Return to GOV.UK
 technical.other-ways.h1=Other Ways to apply for Marriage Allowance
 technical.other-ways.para1=We were unable to confirm your identity online. Call HM Revenue and Customs (HMRC) to claim Marriage Allowance.
-technical.other-ways.para2=You''ll need to know you and your spouse or civil partner''s National Insurance number when you call.
+technical.other-ways.para2=You’ll need to know you and your spouse or civil partner’s National Insurance number when you call.
 title.cannot-find-details = Cannot find details
 title.technical-error = Technical Error
 technical.cannot-find-details.h1 = We cannot find your Marriage Allowance details
@@ -502,7 +502,7 @@ radio.no=No
 pages.history.help.partner=You are currently helping your partner benefit from Marriage Allowance.
 pages.history.helped.by.partner=Your partner is currently helping you benefit from Marriage Allowance.
 pages.history.cancellation=You can cancel Marriage Allowance online
-pages.history.cancellation1=If you’'ve divorced or ended your civil partnership, you can cancel Marriage Allowance online. If you''re currently separated, you can still receive Marriage Allowance until you legally end your marriage or civil partnership.
+pages.history.cancellation1=If you’'ve divorced or ended your civil partnership, you can cancel Marriage Allowance online. If you’re currently separated, you can still receive Marriage Allowance until you legally end your marriage or civil partnership.
 pages.history.cancellation2=You can also cancel to stop payments if you’re still married or in a civil partnership, but no longer want to benefit from Marriage Allowance.
 
 pages.history.partner.help=Your partner is currently helping you benefit from Marriage Allowance.
@@ -515,11 +515,11 @@ pages.history.button.remove=Remove allowance
 
 #eligible year page
 pages.eligibleyear.currentyear=You can apply for the current tax year
-pages.eligibleyear.toldus=You''ve told us you married or formed a civil partnership with <span id="firstNameOnly">{0}</span> on
+pages.eligibleyear.toldus=You’ve told us you married or formed a civil partnership with <span id="firstNameOnly">{0}</span> on
 pages.eligibleyear.thisyear=This current tax year</span><br>{0} onwards
 pages.eligibleyear.li1={0} will pay up to £{1} less tax each year
-pages.eligibleyear.li2=we''ll adjust <span id="firstNameOnly3">{0}</span> tax code to include this extra allowance
-pages.eligibleyear.li3=it''ll automatically renew every year until you or <span id="firstNameOnly4">{0}</span> cancel it or are <a href="https://www.gov.uk/marriage-allowance-guide/if-your-circumstances-change">no longer eligible</a>
+pages.eligibleyear.li2=we’ll adjust <span id="firstNameOnly3">{0}</span> tax code to include this extra allowance
+pages.eligibleyear.li3=it’ll automatically renew every year until you or <span id="firstNameOnly4">{0}</span> cancel it or are <a href="https://www.gov.uk/marriage-allowance-guide/if-your-circumstances-change">no longer eligible</a>
 pages.eligibleyear.doyou.want=Do you want to apply for this current tax year onwards?
 pages.eligibleyear.notice=You can apply for earlier years if you continue.
 
@@ -536,12 +536,12 @@ pages.previousyear.para=You told us you married or formed a civil partnership wi
 
 #confirm-page
 pages.confirm.lower.earner=Your details (the lower earner)
-pages.confirm.higher.earner=Your partner''s details (the higher earner)
+pages.confirm.higher.earner=Your partner’s details (the higher earner)
 pages.confirm.current.tax=Current tax year: {0} onwards
 pages.confirm.current.tax.desc=HMRC will change your and {0} tax codes to save {1} up to £{2}. Marriage Allowance will automatically continue until you or {3} cancel it or are no longer eligible as a couple.
 pages.confirm.previous.tax=Previous tax year: {0} to {1}
-pages.confirm.previous.tax.desc=HMRC will check the details you''ve supplied before sending {0} a cheque by post for up to {1}.
-pages.confirm.warning=Check the details you''ve entered and make sure this is the person you want to claim Marriage Allowance with.
+pages.confirm.previous.tax.desc=HMRC will check the details you’ve supplied before sending {0} a cheque by post for up to {1}.
+pages.confirm.warning=Check the details you’ve entered and make sure this is the person you want to claim Marriage Allowance with.
 pages.confirm.button=Confirm your application
 pages.confirm.marriage.details=Your Marriage Allowance details
 pages.confirm.date.of.marriage=Date of marriage or formation of civil partnership
@@ -549,10 +549,10 @@ pages.confirm.date.of.marriage=Date of marriage or formation of civil partnershi
 #change-of-circs-finish-page
 pages.coc.finish.header=Marriage Allowance cancelled
 pages.coc.finish.acknowledgement=An email acknowledging your cancellation will be sent to you at <strong>{0}</strong> from <strong>noreply&#64;tax.service.gov.uk</strong> within 24 hours.
-pages.coc.finish.junk=If it doesn''t appear in your inbox, please check your spam or junk folder.
+pages.coc.finish.junk=If it doesn’t appear in your inbox, please check your spam or junk folder.
 pages.coc.finish.whn=What happens next
-pages.coc.finish.para1=HMRC will now process your cancellation. Please check the email we''ve sent you for full details.
-pages.coc.finish.para2=There''s no need to contact us. You can <a href="history">check the status</a> of your Marriage Allowance online.
+pages.coc.finish.para1=HMRC will now process your cancellation. Please check the email we’ve sent you for full details.
+pages.coc.finish.para2=There’s no need to contact us. You can <a href="history">check the status</a> of your Marriage Allowance online.
 
 date.fields.day=Day
 date.fields.month=Month
@@ -569,7 +569,7 @@ change.other.bereavement.link=To let us know about a bereavement, contact HMRC
 error.invalid.date.format=You must specify a valid date.
 
 #no years selected page
-pages.noyears.h1=You haven''t selected any tax years to apply for
+pages.noyears.h1=You haven’t selected any tax years to apply for
 pages.noyears.content1=Go back if you want to select a year to apply for.
 pages.noyears.findoutmore=You can find out more about <a href="https://www.gov.uk/marriage-allowance-guide/how-it-works">how Marriage Allowance works.</a>
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -27,13 +27,13 @@ pages.form.field.gender.error.error.required	=	Rhowch wybod beth yw rhyw eich pr
 pages.form.field.gender.error.error.invalid	=	Rhowch wybod beth yw rhyw eich priod neu bartner sifil.
 pages.form.field.dom.error.required	=	Rhowch wybod ar ba ddyddiad y gwnaethoch briodi.
 pages.form.field.dod.error.required	=	Rhowch wybod ar ba ddyddiad y gwnaethoch ysgaru.
-pages.form.field.dom.error.min-date	=	Mae''r dyddiad hwn yn rhy bell yn y gorffennol.
-pages.form.field.dom.error.max-date	=	Mae''r dyddiad hwn yn y dyfodol.
+pages.form.field.dom.error.min-date	=	Mae’r dyddiad hwn yn rhy bell yn y gorffennol.
+pages.form.field.dom.error.max-date	=	Mae’r dyddiad hwn yn y dyfodol.
 
 pages.form.field.description.nino	=	Cadarnhewch rif Yswiriant Gwladol eich priod neu bartner sifil
 pages.form.field.nino.error.error.required	=	Rhowch wybod beth yw rhif Yswiriant Gwladol eich priod neu bartner sifil.
-pages.form.field.nino.error.error.invalid	=	Rhaid i chi wirio''r rhif Yswiriant Gwladol a''i nodi''n gywir.
-pages.form.field.nino.error.self	=	Ni allwch nodi''ch manylion eich hun.
+pages.form.field.nino.error.error.invalid	=	Rhaid i chi wirio’r rhif Yswiriant Gwladol a’i nodi’n gywir.
+pages.form.field.nino.error.self	=	Ni allwch nodi’ch manylion eich hun.
 
 pages.form.field.description.dateOfMarriage	=	Cadarnhewch eich dyddiad priodi
 pages.form.field.description-alt.dateOfDivorce	=	Cadarnhewch eich dyddiad ysgaru
@@ -41,19 +41,19 @@ pages.form.field.description-alt.dateOfDivorce	=	Cadarnhewch eich dyddiad ysgaru
 pages.form.field.description.transferor-email	=	Cadarnhewch eich cyfeiriad e-bost
 pages.form.field.transferor-email.error.error.maxLength	=	Nodwch ddim mwy na {0} o gymeriadau.
 pages.form.field.transferor-email.error.error.email	=	Rhowch gyfeiriad e-bost dilys.
-pages.form.field.transferor-email.error.error.required	=	Rhowch wybod beth yw''ch cyfeiriad e-bost.
+pages.form.field.transferor-email.error.error.required	=	Rhowch wybod beth yw’ch cyfeiriad e-bost.
 
-pages.form.field.description.marriage-criteria	=	Cadarnhewch a ydych yn briod neu mewn partneriaeth sifil sydd wedi''i chofrestru''n gyfreithlon
-pages.form.field.description.lower-earner	=	Cadarnhewch os mai chi yw''r un â''r cyflog isaf yn y berthynas
+pages.form.field.description.marriage-criteria	=	Cadarnhewch a ydych yn briod neu mewn partneriaeth sifil sydd wedi’i chofrestru’n gyfreithlon
+pages.form.field.description.lower-earner	=	Cadarnhewch os mai chi yw’r un â’r cyflog isaf yn y berthynas
 
-pages.form.field.description.multiyear-transferor-income-criteria	=	Rhowch wybod a oedd eich incwm blynyddol er 6 Ebrill 2015 ar lefel y Lwfans Personol neu''n is.
-pages.form.field.description.multiyear-recipient-income-criteria	=	Rhowch wybod a yw''ch priod neu bartner sifil yn talu treth ar y gyfradd sylfaenol er 6 Ebrill 2015.
+pages.form.field.description.multiyear-transferor-income-criteria	=	Rhowch wybod a oedd eich incwm blynyddol er 6 Ebrill 2015 ar lefel y Lwfans Personol neu’n is.
+pages.form.field.description.multiyear-recipient-income-criteria	=	Rhowch wybod a yw’ch priod neu bartner sifil yn talu treth ar y gyfradd sylfaenol er 6 Ebrill 2015.
 
-pages.form.field-required.marriage-criteria	=	Rhowch wybod a ydych yn briod neu mewn partneriaeth sifil sydd wedi''i chofrestru''n gyfreithlon.
-pages.form.field-required.multiyear-recipient-income-criteria	=	Rhowch wybod a yw''ch priod neu bartner sifil yn talu treth ar y gyfradd sylfaenol er 6 Ebrill 2015.
-pages.form.field-required.multiyear-transferor-income-criteria	=	Rhowch wybod a oedd eich incwm blynyddol er 6 Ebrill 2015 ar lefel y Lwfans Personol neu''n is.
+pages.form.field-required.marriage-criteria	=	Rhowch wybod a ydych yn briod neu mewn partneriaeth sifil sydd wedi’i chofrestru’n gyfreithlon.
+pages.form.field-required.multiyear-recipient-income-criteria	=	Rhowch wybod a yw’ch priod neu bartner sifil yn talu treth ar y gyfradd sylfaenol er 6 Ebrill 2015.
+pages.form.field-required.multiyear-transferor-income-criteria	=	Rhowch wybod a oedd eich incwm blynyddol er 6 Ebrill 2015 ar lefel y Lwfans Personol neu’n is.
 
-pages.form.field-required.lower-earner	=	Rhowch wybod os mai chi yw''r un â''r cyflog isaf yn y berthynas.
+pages.form.field-required.lower-earner	=	Rhowch wybod os mai chi yw’r un â’r cyflog isaf yn y berthynas.
 
 pages.form.field-required.applyForCurrentYear	=	Rhowch wybod a hoffech wneud cais ar gyfer y flwyddyn dreth bresennol.
 pages.form.field-required.applyForHistoricYears	=	Rhowch wybod a hoffech wneud cais ar gyfer blynyddoedd treth cynharach.
@@ -75,37 +75,37 @@ pages.form.field.description.year-2024-	=	Cadarnhewch a hoffech wneud cais ar gy
 pages.form.field.description.year-2025-	=	Cadarnhewch a hoffech wneud cais ar gyfer y flwyddyn dreth flaenorol, sef 2025 i 2026
 pages.form.field.description.year-2026-	=	Cadarnhewch a hoffech wneud cais ar gyfer y flwyddyn dreth flaenorol, sef 2026 i 2027
 
-pages.form.field.transferor-income.error.field-required	=	Rhowch wybod beth yw''ch incwm blynyddol.
-pages.form.field.transferor-income.error.field-invalid	=	Defnyddiwch rifau''n unig.
+pages.form.field.transferor-income.error.field-required	=	Rhowch wybod beth yw’ch incwm blynyddol.
+pages.form.field.transferor-income.error.field-invalid	=	Defnyddiwch rifau’n unig.
 
-eligibility.feedback.incorrect-role	=	Gwiriwch y rhifau yr ydych wedi''u nodi. Nodwch incwm yr unigolyn &#226;''r cyflog isaf, wedi''i ddilyn gan incwm yr unigolyn &#226;''r cyflog uchaf.
+eligibility.feedback.incorrect-role	=	Gwiriwch y rhifau yr ydych wedi’u nodi. Nodwch incwm yr unigolyn &#226;’r cyflog isaf, wedi’i ddilyn gan incwm yr unigolyn &#226;’r cyflog uchaf.
 
 pages.form.field.recipient-income.error.field-required	=	Rhowch wybod beth yw incwm blynyddol eich priod neu bartner sifil.
-pages.form.field.recipient-income.error.field-invalid	=	Defnyddiwch rifau''n unig.
+pages.form.field.recipient-income.error.field-invalid	=	Defnyddiwch rifau’n unig.
 
-change.status.reason-CANCEL	=	Rwyf am roi''r gorau i gael taliadau Lwfans Priodasol
-change.status.reason-REJECT	=	Rwyf am roi''r gorau i gael taliadau Lwfans Priodasol
+change.status.reason-CANCEL	=	Rwyf am roi’r gorau i gael taliadau Lwfans Priodasol
+change.status.reason-REJECT	=	Rwyf am roi’r gorau i gael taliadau Lwfans Priodasol
 change.status.reason-DIVORCE_CY	=	Ysgariad neu ddiwedd partneriaeth sifil
 change.status.reason-DIVORCE_PY	=	Ysgariad neu ddiwedd partneriaeth sifil
 
 change.status.relevantDate-CANCEL	=	Caiff hyn ei ddileu ar ddiwedd y flwyddyn dreth ({0}).
-change.status.relevantDate-REJECT	=	Caiff hyn ei ddileu o ddechrau''r flwyddyn dreth y cawsoch Lwfans Priodasol ({0}) am y tro cyntaf.
+change.status.relevantDate-REJECT	=	Caiff hyn ei ddileu o ddechrau’r flwyddyn dreth y cawsoch Lwfans Priodasol ({0}) am y tro cyntaf.
 change.status.relevantDate-DIVORCE_CY	=	Caiff hyn ei ddileu o ddiwedd y flwyddyn dreth pan wnaethoch ysgaru ({0}).
-change.status.relevantDate-DIVORCE_PY	=	Caiff hyn ei ddileu o ddechrau''r flwyddyn dreth ({0}).
+change.status.relevantDate-DIVORCE_PY	=	Caiff hyn ei ddileu o ddechrau’r flwyddyn dreth ({0}).
 
 error.end-reason.required	=	Dewiswch reswm dros newid eich Lwfans Priodasol isod.
 pages.form.field.description.endReason	=	Dewiswch reswm dros newid eich Lwfans Priodasol isod
-error.divorce-reason.required	=	Dewiswch ateb am gadw''ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth.
-pages.form.field.description-alt.endReason	=	Dewiswch ateb am gadw''ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth
+error.divorce-reason.required	=	Dewiswch ateb am gadw’ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth.
+pages.form.field.description-alt.endReason	=	Dewiswch ateb am gadw’ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth
 
 coc.end-reason.DEATH	=	Profedigaeth
 coc.end-reason.DIVORCE	=	Ysgariad neu ddiwedd partneriaeth sifil
 coc.end-reason.INELIGIBLE_PARTICIPANT	=	Gwneud Cais am Lwfans P&#226;r Priod
-coc.end-reason.INVALID_PARTICIPANT	=	Nid yw''r unigolyn &#226;''r cyflog uchaf yn gymwys ar gyfer Lwfans Priodasol
-coc.end-reason.CANCELLED	=	Lwfans wedi''i ganslo
-coc.end-reason.REJECTED	=	Lwfans wedi''i ganslo
+coc.end-reason.INVALID_PARTICIPANT	=	Nid yw’r unigolyn &#226;’r cyflog uchaf yn gymwys ar gyfer Lwfans Priodasol
+coc.end-reason.CANCELLED	=	Lwfans wedi’i ganslo
+coc.end-reason.REJECTED	=	Lwfans wedi’i ganslo
 coc.end-reason.HMRC	=	CThEM wedi dod ag ef i ben
-coc.end-reason.CLOSED	=	Nid yw''r unigolyn &#226;''r cyflog isaf yn gymwys ar gyfer Lwfans Priodasol
+coc.end-reason.CLOSED	=	Nid yw’r unigolyn &#226;’r cyflog isaf yn gymwys ar gyfer Lwfans Priodasol
 coc.end-reason.MERGER	=	Uno cyfrifon cwsmeriaid
 coc.end-reason.RETROSPECTIVE	=	Wedi gwneud cais am Lwfans Priodasol yn &#244;l-weithredol
 coc.end-reason.SYSTEM	=	CThEM wedi dod ag ef i ben
@@ -155,37 +155,37 @@ generic.transferor-action	=	Wedi trosglwyddo Lwfans Priodasol
 title.pattern   =   {0} – Lwfans Priodasol – GOV.UK
 title.eligibility.pattern   =   {0} – Lwfans Priodasol: Bod yn gymwys ar ei gyfer – GOV.UK
 title.application.pattern   =   {0} – Cais am Lwfans Priodasol – GOV.UK
-title.verify    =   Cadarnhau''ch manylion personol
+title.verify    =   Cadarnhau’ch manylion personol
 title.dateOfBirth   =   Eich dyddiad geni
 title.eligible-years    =   Gwneud cais ar gyfer y flwyddyn dreth bresennol
 title.extra-years   =   Gwneud cais ar gyfer blynyddoedd treth cynharach
 title.transfer-in-place =   Trosglwyddiad yn barod
 title.transfer  =   Manylion eich partner
-title.finished  =   Cais wedi''i gadarnhau
-title.confirm-email =   Cadarnhau''ch cyfeiriad e-bost
+title.finished  =   Cais wedi’i gadarnhau
+title.confirm-email =   Cadarnhau’ch cyfeiriad e-bost
 title.non-eligible  =   Nid ydych yn gymwys ar gyfer y flwyddyn dreth bresennol
 title.no-tax-years  =   Dim blynyddoedd treth ar gael
 title.eligibility   =   Eich perthynas
 title.confirm-transferor    =   Cadarnhau canslo
 title.confirm-recipient =   Cadarnhau dileu cais blaenorol
 title.confirm-update    =   Cadarnhau diweddaru
-title.confirm   =   Gwirio''ch manylion a chadarnhau''r cais
+title.confirm   =   Gwirio’ch manylion a chadarnhau’r cais
 title.eligibility-criteria  =   Meini prawf cymhwysedd
 title.how-it-works  =   Gwneud cais am Lwfans Priodasol
 title.other-ways    =   Ffyrdd eraill o wneud cais
-title.change.complete   =   Lwfans Priodasol wedi''i ganslo
+title.change.complete   =   Lwfans Priodasol wedi’i ganslo
 title.change.earnings   =  Newid mewn incwm
 title.change.reason =   Dileu cais blaenorol
 title.complete  = Cwblhau
 title.error =   Gwall
-title.history   =   Crynodeb o''ch Lwfans Priodasol
-title.make-a-change =   Canslo''ch Lwfans Priodasol
+title.history   =   Crynodeb o’ch Lwfans Priodasol
+title.make-a-change =   Canslo’ch Lwfans Priodasol
 title.bereavement   =  Profedigaeth
-title.divorce   =  Dyddiad ysgaru neu ddod &#226;''r bartneriaeth sifil i ben
-title.date-of-marriage  = Dyddiad y briodas neu ffurfio''r bartneriaeth sifil
+title.divorce   =  Dyddiad ysgaru neu ddod &#226;’r bartneriaeth sifil i ben
+title.date-of-marriage  = Dyddiad y briodas neu ffurfio’r bartneriaeth sifil
 
 #User status
-user-status.first-time-login	=	{0} yw''r tro cyntaf i chi fewngofnodi
+user-status.first-time-login	=	{0} yw’r tro cyntaf i chi fewngofnodi
 user-status.previous-login-time	=	{0} mewngofnodi diwethaf {1}
 user-status.sign-out	=	Allgofnodi
 
@@ -194,11 +194,11 @@ hmrc.contact-details	=	Gallwch gysylltu &#226; CThEM ar:
 hmrc.contact-details-1	=	Gallwch roi gwybod i CThEM am newid mewn incwm ar:
 hmrc.contact-details-2	=	Ff&#244;n: 0300 200 3300
 hmrc.contact-details-3	=	Ff&#244;n testun: 0300 200 3319
-hmrc.contact-details-4	=	Y tu allan i''r DU: +44 135 535 9022
+hmrc.contact-details-4	=	Y tu allan i’r DU: +44 135 535 9022
 hmrc.contact-detials.time	=	Oriau agor
 hmrc.contact-details-5	=	08:00 – 20:00, Dydd Llun – Dydd Gwener
 hmrc.contact-details-6	=	08:00 – 16:00, Dydd Sadwrn
-hmrc.contact-details-7	=	Ar gau ar Ddydd Sul a gwyliau''r banc
+hmrc.contact-details-7	=	Ar gau ar Ddydd Sul a gwyliau’r banc
 hmrc.contact-detials.calling.time	=	Yr amser gorau i gysylltu &#226; ni
 hmrc.contact-details-8	=	Mae llinellau ffon yn llai prysur cyn 10:00, Dydd Llun i Ddydd Gwener
 hmrc.contact-details-9	=	<a href="https://www.gov.uk/call-charges"> Gwybodaeth am gost galwadau</a>
@@ -206,16 +206,16 @@ hmrc.contact-details-9	=	<a href="https://www.gov.uk/call-charges"> Gwybodaeth a
 #Eligibility Calculator
 pages.calc.header	=	Cyfrifiannell Lwfans Priodasol
 pages.calc.para1	=	Fel p&#226;r, darganfyddwch faint o dreth y gallwch ei harbed os ydych yn gwneud cais am Lwfans Priodasol yn y flwyddyn dreth hon.
-pages.form.field.income	=	Incwm blynyddol yr unigolyn &#226;''r cyflog isaf cyn didynnu treth
-pages.form.field.recipient-income	=	Incwm blynyddol yr unigolyn &#226;''r cyflog uchaf cyn didynnu treth
+pages.form.field.income	=	Incwm blynyddol yr unigolyn &#226;’r cyflog isaf cyn didynnu treth
+pages.form.field.recipient-income	=	Incwm blynyddol yr unigolyn &#226;’r cyflog uchaf cyn didynnu treth
 pages.calc.field-helper.income	=	Dyma ffigur eich incwm cyn didynnu treth.
 pages.calc.field-helper.partners-income	=	Dyma ffigur ei (h)incwm cyn didynnu treth.
 pages.calc.how-to-apply	=	Sut i wneud cais
-pages.calc.skip-it.pre	=	Mae''r cam hwn yn opsiynol.
+pages.calc.skip-it.pre	=	Mae’r cam hwn yn opsiynol.
 pages.calc.skip-it	=	Ewch heibio
 estimate.tax.saving	=	Cyfrifo
-eligibility.feedback.gain	=	Ar sail yr wybodaeth yr ydych wedi''i rhoi i ni, byddech yn elwa o tua <strong>£{0}</strong> y flwyddyn fel p&#226;r.
-eligibility.feedback.loose	=	Ar sail y manylion yr ydych wedi''i rhoi, ni fyddwch yn elwa o wneud y trosglwyddiad.
+eligibility.feedback.gain	=	Ar sail yr wybodaeth yr ydych wedi’i rhoi i ni, byddech yn elwa o tua <strong>£{0}</strong> y flwyddyn fel p&#226;r.
+eligibility.feedback.loose	=	Ar sail y manylion yr ydych wedi’i rhoi, ni fyddwch yn elwa o wneud y trosglwyddiad.
 
 #Multi-year select
 pages.multi-year-select.heading	=	Cadarnhewch y blynyddoedd cynharach yr ydych am wneud cais ar eu cyfer
@@ -223,26 +223,26 @@ pages.multi-year-select.heading	=	Cadarnhewch y blynyddoedd cynharach yr ydych a
 ############################
 #Should be added every year#
 ############################
-eligibility.feedback.transferor-not-eligible-2016	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Fel yr unigolyn sy''n gwneud y trosglwyddiad, mae''n rhaid i''ch incwm fod yn llai na £43,000.
-eligibility.feedback.transferor-not-eligible-2017	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Fel yr unigolyn sy''n gwneud y trosglwyddiad, mae''n rhaid i''ch incwm fod yn llai na £45,000.
+eligibility.feedback.transferor-not-eligible-2016	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Fel yr unigolyn sy’n gwneud y trosglwyddiad, mae’n rhaid i’ch incwm fod yn llai na £43,000.
+eligibility.feedback.transferor-not-eligible-2017	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Fel yr unigolyn sy’n gwneud y trosglwyddiad, mae’n rhaid i’ch incwm fod yn llai na £45,000.
 eligibility.feedback.recipient-not-eligible-2016	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Rhaid i incwm blynyddol eich priod neu bartner sifil fod rhwng £11,001 a £43,000.
 eligibility.feedback.recipient-not-eligible-2017	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol. Rhaid i incwm blynyddol eich priod neu bartner sifil fod rhwng £11,501 a £45,000.
-eligibility.check.unlike-benefit-as-couple-2016	=	Rydych yn gymwys ar gyfer Lwfans Priodasol, ond mae''n annhebygol y byddwch yn elwa fel p&#226;r am fod eich incwm dros £11,000.
-eligibility.check.unlike-benefit-as-couple-2017	=	Rydych yn gymwys ar gyfer Lwfans Priodasol, ond mae''n annhebygol y byddwch yn elwa fel p&#226;r am fod eich incwm dros £11,500.
+eligibility.check.unlike-benefit-as-couple-2016	=	Rydych yn gymwys ar gyfer Lwfans Priodasol, ond mae’n annhebygol y byddwch yn elwa fel p&#226;r am fod eich incwm dros £11,000.
+eligibility.check.unlike-benefit-as-couple-2017	=	Rydych yn gymwys ar gyfer Lwfans Priodasol, ond mae’n annhebygol y byddwch yn elwa fel p&#226;r am fod eich incwm dros £11,500.
 max-benefit-2014	=	£212
 max-benefit-2015	=	£212
 max-benefit-2016	=	£220
 max-benefit-2017	=	£230
-your-income-2015	=	os oedd eich incwm yn £10,600 neu''n llai
-your-income-2016	=	os oedd eich incwm yn £11,000 neu''n llai
-your-income-2017	=	os oedd eich incwm yn £11,500 neu''n llai
+your-income-2015	=	os oedd eich incwm yn £10,600 neu’n llai
+your-income-2016	=	os oedd eich incwm yn £11,000 neu’n llai
+your-income-2017	=	os oedd eich incwm yn £11,500 neu’n llai
 income-between-2015	=	os oedd incwm rhwng {0} £10,601 a £42,385
 income-between-2016	=	os oedd incwm rhwng {0} £11,001 a £43,000
 income-between-2017	=	os oedd incwm rhwng {0} £11,501 a £45,000
 
 #Confirmation Message
-pages.confirm.html.h1	=	Gwirio''ch manylion a chadarnhau''r cais
-pages.confirm.html.check-details	=	Dylech wirio''r manylion yr ydych wedi''i rhoi, a chadarnhau mai''r unigolyn hwn yw''ch priod neu bartner sifil. Yna, gallwch wneud cais i drosglwyddo £1,050 o''ch Lwfans Personol iddo/iddi.
+pages.confirm.html.h1	=	Gwirio’ch manylion a chadarnhau’r cais
+pages.confirm.html.check-details	=	Dylech wirio’r manylion yr ydych wedi’i rhoi, a chadarnhau mai’r unigolyn hwn yw’ch priod neu bartner sifil. Yna, gallwch wneud cais i drosglwyddo £1,050 o’ch Lwfans Personol iddo/iddi.
 
 #Eligibility Check
 eligibility.check.header	=	A ydych yn gymwys?
@@ -250,26 +250,26 @@ eligibility.check.h1	=	Eich perthynas
 eligibility.check.span.h1	=	Gwiriwch a ydych yn gymwys
 eligibility.check.span.para	=	Er mwyn gwneud cais am Lwfans Priodasol, rhaid i chi fod yn briod neu mewn partneriaeth sifil.
 eligibility.check.married	=	A yw hyn yn berthnasol i chi?
-eligibility.check.married.legend	=	A ydych yn briod neu mewn partneriaeth sifil sydd wedi''i chofrestru''n gyfreithlon?
+eligibility.check.married.legend	=	A ydych yn briod neu mewn partneriaeth sifil sydd wedi’i chofrestru’n gyfreithlon?
 eligibility.check.yes	=	Iawn
-eligibility.check.married.error	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol am nad ydych yn briod neu mewn partneriaeth sifil sydd wedi''i chofrestru''n gyfreithlon.
-multiyear.check.income	=	Er 6 Ebrill 2015, a oedd eich incwm blynyddol ar lefel y Lwfans Personol neu''n is?
+eligibility.check.married.error	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol am nad ydych yn briod neu mewn partneriaeth sifil sydd wedi’i chofrestru’n gyfreithlon.
+multiyear.check.income	=	Er 6 Ebrill 2015, a oedd eich incwm blynyddol ar lefel y Lwfans Personol neu’n is?
 eligibility.check.non-eligible	=	Ar sail eich atebion, nid ydych yn gymwys ar gyfer Lwfans Priodasol.
-eligibility.check.lower.earner.information1	=	Er mwyn elwa o Lwfans Priodasol, chi sy''n gorfod ennill y lleiaf yn y berthynas ac ennill £{0} neu lai''r flwyddyn.
+eligibility.check.lower.earner.information1	=	Er mwyn elwa o Lwfans Priodasol, chi sy’n gorfod ennill y lleiaf yn y berthynas ac ennill £{0} neu lai’r flwyddyn.
 eligibility.check.lower.earner.information2	=	Dyma ffigur eich incwm cyn didynnu treth.
 eligibility.check.lower.earner.h1	=	Eich incwm
 eligibility.check.lower.earner.question	=	A yw hyn yn berthnasol i chi?
-eligibility.check.lower.earner.error	=	Mae''n bosibl na fyddwch yn elwa o Lwfans Priodasol yn y flwyddyn dreth hon am fod eich incwm yn uwch nag £{0}. Mae''n dal yn bosibl i chi wirio a fyddwch yn elwa ar gyfer blynyddoedd blaenorol os oedd eich incwm yn is yn y gorffennol.
+eligibility.check.lower.earner.error	=	Mae’n bosibl na fyddwch yn elwa o Lwfans Priodasol yn y flwyddyn dreth hon am fod eich incwm yn uwch nag £{0}. Mae’n dal yn bosibl i chi wirio a fyddwch yn elwa ar gyfer blynyddoedd blaenorol os oedd eich incwm yn is yn y gorffennol.
 eligibility.check.partners.income.h1	=	Incwm eich partner
-eligibility.check.partners.income.information1	=	Er mwyn bod yn gymwys ar gyfer Lwfans Priodasol, rhaid i''ch partner fod yn ennill rhwng £{0} a £{1} y flwyddyn.
+eligibility.check.partners.income.information1	=	Er mwyn bod yn gymwys ar gyfer Lwfans Priodasol, rhaid i’ch partner fod yn ennill rhwng £{0} a £{1} y flwyddyn.
 eligibility.check.partners.income.information2	=	Dyma ffigur ei (h)incwm cyn didynnu treth.
-eligibility.check.partners.income.h2	=	A yw hyn yn berthnasol i''ch partner?
+eligibility.check.partners.income.h2	=	A yw hyn yn berthnasol i’ch partner?
 eligibility.check.partners.income.before.tax	=	Dyma ffigur ei (h)incwm cyn didynnu treth.
-eligibility.check.partners.income.error	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol yn y flwyddyn dreth hon am fod incwm eich partner yn rhy uchel neu''n rhy isel. Mae''n dal yn bosibl i chi wirio''ch cymhwyster am flynyddoedd blaenorol.
-eligibility.check.date.of.birth.h1  =   Eich dyddiad geni chi a''ch partner
-eligibility.check.date.of.birth.span.para   =   I elwa o Lwfans Priodasol, dylai''ch dyddiad geni chi a''ch partner fod ar neu ar &#244;l 6 Ebrill 1935.
-eligibility.check.date.of.birth.span.married    =   A yw hyn yn berthnasol i chi a''ch partner?
-eligibility.check.date.of.birth.error   =   Os yw''ch dyddiad geni chi neu''ch partner cyn 6 Ebrill 1935, efallai y gallwch elwa''n fwy fel p&#226;r os gwnewch gais am <a href="https://www.gov.uk/married-couples-allowance" target="_blank">Lwfans P&#226;r Priod</a>.<p></p>Mae''n dal i fod yn bosibl i chi barhau a gwneud cais am Lwfans Priodasol yn ei le. Fodd bynnag, ni allwch gael Lwfans Priodasol a Lwfans P&#226;r Priod ar yr un pryd.
+eligibility.check.partners.income.error	=	Nid ydych yn gymwys ar gyfer Lwfans Priodasol yn y flwyddyn dreth hon am fod incwm eich partner yn rhy uchel neu’n rhy isel. Mae’n dal yn bosibl i chi wirio’ch cymhwyster am flynyddoedd blaenorol.
+eligibility.check.date.of.birth.h1  =   Eich dyddiad geni chi a’ch partner
+eligibility.check.date.of.birth.span.para   =   I elwa o Lwfans Priodasol, dylai’ch dyddiad geni chi a’ch partner fod ar neu ar &#244;l 6 Ebrill 1935.
+eligibility.check.date.of.birth.span.married    =   A yw hyn yn berthnasol i chi a’ch partner?
+eligibility.check.date.of.birth.error   =   Os yw’ch dyddiad geni chi neu’ch partner cyn 6 Ebrill 1935, efallai y gallwch elwa’n fwy fel p&#226;r os gwnewch gais am <a href="https://www.gov.uk/married-couples-allowance" target="_blank">Lwfans P&#226;r Priod</a>.<p></p>Mae’n dal i fod yn bosibl i chi barhau a gwneud cais am Lwfans Priodasol yn ei le. Fodd bynnag, ni allwch gael Lwfans Priodasol a Lwfans P&#226;r Priod ar yr un pryd.
 
 #Verify
 pages.verify_triage.header	=	Gwirio manylion adnabod
@@ -280,18 +280,18 @@ pages.verify_triage.para2	=	Caiff cwestiynau eu gofyn i chi nawr yn seiliedig ar
 pages.finished.successful	=	Cais am Lwfans Priodasol yn llwyddiannus
 pages.finished.para1.email1	=	Bydd e-bost &#226; manylion llawn yn cael ei anfon atoch yn  {0} i gydnabod eich cais, a hynny
 pages.finished.para1.email2	=	o noreply@tax.service.gov.uk cyn pen 24 awr.
-pages.finished.para2	=	Os nad yw''n ymddangos yn eich mewnflwch, edrychwch yn eich ffolder sbam neu sothach.
-pages.finished.now	=	Yr hyn sy''n digwydd nesaf
-pages.finished.para4	=	Bydd CThEM yn prosesu''ch cais am Lwfans Priodasol. Gwiriwch yr e-bost yr ydym wedi''i anfon atoch am fanylion llawn ynghylch sut y byddwch yn cael Lwfans Priodasol.
-pages.finished.para5	=	Os ydynt yn gyflogedig ac yn talu treth trwy TWE, byddwn yn anfon hysbysiad o god treth diwygiedig ato/ati drwy''r post. Byddwn hefyd yn rhoi gwybod i''r cyflogwr i ddechrau defnyddio''r cod treth newydd.
+pages.finished.para2	=	Os nad yw’n ymddangos yn eich mewnflwch, edrychwch yn eich ffolder sbam neu sothach.
+pages.finished.now	=	Yr hyn sy’n digwydd nesaf
+pages.finished.para4	=	Bydd CThEM yn prosesu’ch cais am Lwfans Priodasol. Gwiriwch yr e-bost yr ydym wedi’i anfon atoch am fanylion llawn ynghylch sut y byddwch yn cael Lwfans Priodasol.
+pages.finished.para5	=	Os ydynt yn gyflogedig ac yn talu treth trwy TWE, byddwn yn anfon hysbysiad o god treth diwygiedig ato/ati drwy’r post. Byddwn hefyd yn rhoi gwybod i’r cyflogwr i ddechrau defnyddio’r cod treth newydd.
 pages.finished.para6	=	Bydd eich hysbysiad o god treth diwygiedig yn ymddangos yn eich cyfrif treth personol cyn pen 24 awr.
 pages.finished.para7	=	Nid oes angen i chi gysylltu &#226; ni.
-pages.finished.back-pta	=	Yn &#244;l i''r Cyfrif Treth Personol
-pages.finished.check-link-para	=	Gallwch <a id="pta-link" href="{0}" data-journey-click="marriage-allowance:outboundlink:ptaclick_finish" >wirio''ch Lwfans Priodasol presennol a gwneud newidiadau</a> ar unrhyw bryd drwy''ch cyfrif treth personol.
+pages.finished.back-pta	=	Yn &#244;l i’r Cyfrif Treth Personol
+pages.finished.check-link-para	=	Gallwch <a id="pta-link" href="{0}" data-journey-click="marriage-allowance:outboundlink:ptaclick_finish" >wirio’ch Lwfans Priodasol presennol a gwneud newidiadau</a> ar unrhyw bryd drwy’ch cyfrif treth personol.
 
 #Registration page - Your spouse details
 pages.form.h1	=	Manylion eich priod neu bartner sifil
-pages.form.details	=	Fel yr unigolyn &#226;''r cyflog isaf, gallwch chi <span id="transferor-name">{0}</span> wneud cais nawr i helpu''ch partner i ostwng swm y dreth y mae''n ei dalu.
+pages.form.details	=	Fel yr unigolyn &#226;’r cyflog isaf, gallwch chi <span id="transferor-name">{0}</span> wneud cais nawr i helpu’ch partner i ostwng swm y dreth y mae’n ei dalu.
 pages.form.enter-data	=	Nodwch fanylion eich priod neu bartner sifil:
 pages.form.field.name	=	Beth yw enw cyntaf eich priod neu bartner sifil?
 pages.form.field.last-name	=	Beth yw enw olaf eich priod neu bartner sifil?
@@ -302,33 +302,33 @@ pages.form.field-helper.gender	=	Bydd yr wybodaeth hon yn ein helpu i gadarnhau 
 pages.form.field.nino	=	Beth yw rhif Yswiriant Gwladol eich priod neu bartner sifil?
 pages.form.field-helper.nino-example	=	Er enghraifft, QQ 12 34 56 C
 pages.form.field-helper.nino-where	=	Ble y gallaf ddod o hyd i hwn?
-pages.form.field-helper.nino-found	=	Mae hwn i''w weld ar gerdyn Yswiriant Gwladol neu ar waith papur swyddogol eich priod neu bartner sifil, megis slipiau cyflog, a llythyrau ynghylch budd-daliadau neu gredydau treth.
+pages.form.field-helper.nino-found	=	Mae hwn i’w weld ar gerdyn Yswiriant Gwladol neu ar waith papur swyddogol eich priod neu bartner sifil, megis slipiau cyflog, a llythyrau ynghylch budd-daliadau neu gredydau treth.
 pages.form.field-helper.dom	=	Er enghraifft, 31 3 1980
 pages.form.field-helper.dod	=	Er enghraifft, 31 3 1980
 pages.form.field.your-confirmation	=	E-bost i gadarnhau
-pages.form.field.yourDetails	=	Byddwn yn e-bostio cadarnhad o''ch cais am Lwfans Priodasol cyn pen 24 awr. Ni fyddwn yn rhannu''ch cyfeiriad e-bost gydag unrhyw un arall.
+pages.form.field.yourDetails	=	Byddwn yn e-bostio cadarnhad o’ch cais am Lwfans Priodasol cyn pen 24 awr. Ni fyddwn yn rhannu’ch cyfeiriad e-bost gydag unrhyw un arall.
 pages.form.field.transferor-email	=	Eich cyfeiriad e-bost
 pages.form.field.enter-email	=	Nodwch gyfeiriad e-bost
-pages.form.field.dod	=	Os ydych wedi ymwahanu &#226;''ch priod neu bartner sifil ar hyn o bryd, gallwch barhau i gael Lwfans Priodasol hyd nes eich bod yn dod &#226;''ch priodas neu bartneriaeth sifil i ben yn gyfreithlon.
-pages.form.field.dod.question	=	Pryd y gwnaethoch ddod &#226;''ch priodas neu bartneriaeth sifil i ben yn gyfreithlon?
+pages.form.field.dod	=	Os ydych wedi ymwahanu &#226;’ch priod neu bartner sifil ar hyn o bryd, gallwch barhau i gael Lwfans Priodasol hyd nes eich bod yn dod &#226;’ch priodas neu bartneriaeth sifil i ben yn gyfreithlon.
+pages.form.field.dod.question	=	Pryd y gwnaethoch ddod &#226;’ch priodas neu bartneriaeth sifil i ben yn gyfreithlon?
 
 #Date of Marriage
-pages.date-of-marriage.heading	=	Dyddiad y briodas neu ffurfio''r bartneriaeth sifil
-pages.date-of-marriage.para1	=	Mae hyn er mwyn sicrhau''n bod yn caniat&#225;u i chi elwa o Lwfans Priodasol am y maint cywir o amser.
-pages.date-of-marriage.para2	=	Gallwch wneud cais o''r adeg pan gafodd y Lwfans Priodasol ei gyflwyno am y tro cyntaf, sef 6 Ebrill 2015. O''r herwydd, efallai y gallwch wneud cais ar gyfer blynyddoedd treth blaenorol.
-pages.date-of-marriage.h2	=	Pryd y gwnaethoch briodi neu ffurfio partneriaeth sifil gyda''ch partner?
+pages.date-of-marriage.heading	=	Dyddiad y briodas neu ffurfio’r bartneriaeth sifil
+pages.date-of-marriage.para1	=	Mae hyn er mwyn sicrhau’n bod yn caniat&#225;u i chi elwa o Lwfans Priodasol am y maint cywir o amser.
+pages.date-of-marriage.para2	=	Gallwch wneud cais o’r adeg pan gafodd y Lwfans Priodasol ei gyflwyno am y tro cyntaf, sef 6 Ebrill 2015. O’r herwydd, efallai y gallwch wneud cais ar gyfer blynyddoedd treth blaenorol.
+pages.date-of-marriage.h2	=	Pryd y gwnaethoch briodi neu ffurfio partneriaeth sifil gyda’ch partner?
 
 #How it works
-pages.how-it-works.heading	=	Sut y mae''n gweithio
-pages.how-it-works.lede-pre1	=	Mae <a href="https://www.gov.uk/marriage-allowance-guide">Lwfans Priodasol</a> yn caniat&#225;u i chi drosglwyddo £{0} o''ch Lwfans Personol i''ch priod neu bartner sifil.
+pages.how-it-works.heading	=	Sut y mae’n gweithio
+pages.how-it-works.lede-pre1	=	Mae <a href="https://www.gov.uk/marriage-allowance-guide">Lwfans Priodasol</a> yn caniat&#225;u i chi drosglwyddo £{0} o’ch Lwfans Personol i’ch priod neu bartner sifil.
 pages.how-it-works.lede-pre2	=	Gall hyn ostwng treth eich priod neu bartner sifil hyd at £{0} y flwyddyn dreth hon (6 Ebrill i 5 Ebrill y flwyddyn nesaf).
-pages.how-it-works.lede-pre4	=	Er mwyn elwa fel p&#226;r, mae angen i chi ennill llai na''ch partner a chael incwm o £{0} neu lai.
-pages.how-it-works.lede-pre5	=	Os oeddech yn gymwys ar gyfer Lwfans Priodasol ym mlwyddyn dreth {0} i {1}, gallwch &#244;l-ddyddio''ch cais i {2} a gostwng y dreth a dalwyd hyd at £432.
+pages.how-it-works.lede-pre4	=	Er mwyn elwa fel p&#226;r, mae angen i chi ennill llai na’ch partner a chael incwm o £{0} neu lai.
+pages.how-it-works.lede-pre5	=	Gallwch ôl-ddyddio’ch cais i gynnwys unrhyw flwyddyn dreth ers 5 Ebrill 2015 pan oeddech yn gymwys ar gyfer Lwfans Priodasol.
 pages.how-it-works.lede-in	=	Lwfans Personol
-pages.how-it-works.lede-post	=	i''ch priod neu''ch partner sifil.
+pages.how-it-works.lede-post	=	i’ch priod neu’ch partner sifil.
 pages.how-it-works.tse	=	i weld a ydych yn gymwys ar gyfer Lwfans Priodasol
 pages.how-it-works.apply.heading	=	Cyn i chi wneud cais
-pages.how-it-works.email	=	Cewch e-bost yn cadarnhau''ch cais.
+pages.how-it-works.email	=	Cewch e-bost yn cadarnhau’ch cais.
 pages.how-it-works.detail	=	Mae angen eich rhif Yswiriant Gwladol arnoch, ac un eich partner.
 
 #Change of Circumstances
@@ -336,72 +336,72 @@ change.status.button	=	Canslo Lwfans Priodasol
 change.status.transferor.ha.button	=	Dod &#226; Lwfans Priodasol i ben
 change.status.recipient.ha.button	=	Dod &#226; Lwfans Priodasol i ben
 change.status.recipient.previous.year.button	=	Gwneud cais ar gyfer blynyddoedd blaenorol
-change.status.transferor.p1	=	Gallwch ddileu Lwfans Priodasol os yw un o''r canlynol yn berthnasol:
-change.status.receiver.p1	=	Gallwch ganslo Lwfans Priodasol os yw un o''r canlynol yn berthnasol:
-change.status.transferor.list	=	<li>rydych wedi ysgaru neu ddod &#226;''ch partneriaeth sifil i ben</li><li>mae''ch incwm wedi newid</li><li>rydych am ganslo''r lwfans</li><li>rydych wedi dioddef profedigaeth</li>
-change.status.receiver.list	=	<li>rydych wedi ysgaru neu ddod &#226;''ch partneriaeth sifil i be</li><li>mae''ch incwm wedi newid</li><li>rydych am wrthod y lwfans</li><li>rydych wedi dioddef profedigaeth</li>
+change.status.transferor.p1	=	Gallwch ddileu Lwfans Priodasol os yw un o’r canlynol yn berthnasol:
+change.status.receiver.p1	=	Gallwch ganslo Lwfans Priodasol os yw un o’r canlynol yn berthnasol:
+change.status.transferor.list	=	<li>rydych wedi ysgaru neu ddod &#226;’ch partneriaeth sifil i ben</li><li>mae’ch incwm wedi newid</li><li>rydych am ganslo’r lwfans</li><li>rydych wedi dioddef profedigaeth</li>
+change.status.receiver.list	=	<li>rydych wedi ysgaru neu ddod &#226;’ch partneriaeth sifil i be</li><li>mae’ch incwm wedi newid</li><li>rydych am wrthod y lwfans</li><li>rydych wedi dioddef profedigaeth</li>
 change.status.reason-for	=	Rheswm dros newid
-change.status.reason-for-divorce	=	A ydych am gadw''ch Lwfans Priodasol yn ei le tan {0}?
-change.status.confirm.info	=	Byddwn yn e-bostio cadarnhad eich bod wedi canslo''ch Lwfans Priodasol cyn pen 24 awr.
-change.status.confirm.more.info	=	Ni fyddwn yn rhannu''ch cyfeiriad e-bost gydag unrhyw un arall.
+change.status.reason-for-divorce	=	A ydych am gadw’ch Lwfans Priodasol yn ei le tan {0}?
+change.status.confirm.info	=	Byddwn yn e-bostio cadarnhad eich bod wedi canslo’ch Lwfans Priodasol cyn pen 24 awr.
+change.status.confirm.more.info	=	Ni fyddwn yn rhannu’ch cyfeiriad e-bost gydag unrhyw un arall.
 change.status.confirm-cancellation.button	=	Cadarnhau canslo
 change.status.confirm.field.your-email	=	Byddwn yn anfon cadarnhad atoch i ddweud eich bod wedi canslo.
 change.status.confirm.field.your-name	=	Eich enw
 change.status.earnings.h1	=	Newid mewn incwm
-change.status.earnings.h2	=	Mae angen i chi roi gwybod i ni os yw''ch incwm chi neu''ch partner yn newid er mwyn i ni allu rhoi gwybod i chi:
+change.status.earnings.h2	=	Mae angen i chi roi gwybod i ni os yw’ch incwm chi neu’ch partner yn newid er mwyn i ni allu rhoi gwybod i chi:
 change.status.earnings.tr.instruction-1	=	os bydd gwneud cais am Lwfans Priodasol o fudd i chi fel p&#226;r o hyd
-change.status.earnings.tr.instruction-2	=	os oes angen i chi ganslo''ch Lwfans Priodasol
-change.status.earnings.rec.instruction-1	=	os ydych yn disgwyl i''ch incwm dros y flwyddyn dreth gyfan fod yn fwy na £{0}, oherwydd na fyddwch yn gymwys fel p&#226;r rhagor yn y flwyddyn dreth hon
-change.status.earnings.rec.instruction-2	=	os yw''ch partner yn disgwyl i''w (h)incwm dros y flwyddyn dreth gyfan fod yn fwy na £{0}, oherwydd mae''n bosibl na fyddwch yn elwa o Lwfans Priodasol fel p&#226;r
-change.status.divorce.date.invalid.h1	=	Mae problem gyda''r dyddiadau yr ydych wedi''u nodi
-change.status.divorce.date.invalid.para1	=	Ni all y dyddiad y gwnaethoch ysgaru neu ddiddymu''ch partneriaeth sifil fod cyn y dyddiad y gwnaethoch ddechrau hawlio Lwfans Priodasol.
-change.status.divorce.date.invalid.para2	=	Gallwch fynd yn &#244;l a gwirio bod yr wybodaeth yr ydych wedi''i nodi''n gywir.
-change.status.divorce.date.invalid.para3	=	Cysylltwch &#226; CThEM os ydych o''r farn bod y dyddiad anghywir gennym ar gyfer dechrau''ch priodas neu bartneriaeth sifil.
-change.status.divorce.h1	=	Dyddiad ysgaru neu ddod &#226;''r bartneriaeth sifil i ben
+change.status.earnings.tr.instruction-2	=	os oes angen i chi ganslo’ch Lwfans Priodasol
+change.status.earnings.rec.instruction-1	=	os ydych yn disgwyl i’ch incwm dros y flwyddyn dreth gyfan fod yn fwy na £{0}, oherwydd na fyddwch yn gymwys fel p&#226;r rhagor yn y flwyddyn dreth hon
+change.status.earnings.rec.instruction-2	=	os yw’ch partner yn disgwyl i’w (h)incwm dros y flwyddyn dreth gyfan fod yn fwy na £{0}, oherwydd mae’n bosibl na fyddwch yn elwa o Lwfans Priodasol fel p&#226;r
+change.status.divorce.date.invalid.h1	=	Mae problem gyda’r dyddiadau yr ydych wedi’u nodi
+change.status.divorce.date.invalid.para1	=	Ni all y dyddiad y gwnaethoch ysgaru neu ddiddymu’ch partneriaeth sifil fod cyn y dyddiad y gwnaethoch ddechrau hawlio Lwfans Priodasol.
+change.status.divorce.date.invalid.para2	=	Gallwch fynd yn &#244;l a gwirio bod yr wybodaeth yr ydych wedi’i nodi’n gywir.
+change.status.divorce.date.invalid.para3	=	Cysylltwch &#226; CThEM os ydych o’r farn bod y dyddiad anghywir gennym ar gyfer dechrau’ch priodas neu bartneriaeth sifil.
+change.status.divorce.h1	=	Dyddiad ysgaru neu ddod &#226;’r bartneriaeth sifil i ben
 change.status.divorce.header	=	Eich dyddiad ysgaru
-change.status.divorce-py-heading	=	Dileu''r trosglwyddiad Lwfans Priodasol hwn
-change.status.divorce-py-content	=	Caiff hyn ei ddileu o ddechrau''r flwyddyn dreth bresennol, Ebrill 6{0} ymlaen.
-change.status.divorce.transferor.directions	=	Os ydych yn canslo Lwfans Priodasol, gallwch ddewis naill ai cadw''r lwfans yn ei le tan {0} (diwedd y flwyddyn dreth bresennol) neu ddod ag ef i ben o {1} (dechrau''r flwyddyn dreth bresennol) ymlaen.
+change.status.divorce-py-heading	=	Dileu’r trosglwyddiad Lwfans Priodasol hwn
+change.status.divorce-py-content	=	Caiff hyn ei ddileu o ddechrau’r flwyddyn dreth bresennol, Ebrill 6{0} ymlaen.
+change.status.divorce.transferor.directions	=	Os ydych yn canslo Lwfans Priodasol, gallwch ddewis naill ai cadw’r lwfans yn ei le tan {0} (diwedd y flwyddyn dreth bresennol) neu ddod ag ef i ben o {1} (dechrau’r flwyddyn dreth bresennol) ymlaen.
 change.status.divorce.transferor.h1	=	Canslo Lwfans Priodasol yn sgil ysgariad neu ddod &#226; phartneriaeth sifil i ben
 change.status.divorce.transferor.conditional1.h1	=	Canslo Lwfans Priodasol yn sgil ysgariad neu ddod &#226; phartneriaeth sifil i ben
 
 change.status.divorce.recipient.condition.h1	=	Ysgariad neu ddiwedd partneriaeth sifil
 
-change.status.divorce.transferor.conditional1.para1	=	Rhoesoch wybod y gwnaethoch ysgaru neu ddod &#226;''ch partneriaeth sifil i ben ar {0}.
+change.status.divorce.transferor.conditional1.para1	=	Rhoesoch wybod y gwnaethoch ysgaru neu ddod &#226;’ch partneriaeth sifil i ben ar {0}.
 change.status.divorce.transferor.conditional1.para2	=	Gan fod y dyddiad hwn yn ystod y flwyddyn dreth flaenorol:
 change.status.divorce.transferor.conditional1.para3	=	bydd eich lwfans yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth pan wnaethoch ysgaru
-change.status.divorce.transferor.conditional1.para4	=	os nad yw''ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu''i god treth
-change.status.divorce.transferor.conditional2.para2	=	Gallwch gadw''ch Lwfans Priodasol tan {0}, sef diwedd y flwyddyn dreth pan wnaethoch ysgaru. Bydd eich Lwfans Priodasol yn cael ei ddileu o {1}, sef dechrau''r flwyddyn dreth bresennol ymlaen.
-change.status.divorce.transferor.conditional2.para3	=	Rhown wybod i chi os ydych wedi talu''r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Os nad ydych wedi talu digon, byddwn yn ei chasglu drwy addasu''ch cod treth.
-change.status.divorce.transferor.option1	=	Os ydych yn penderfynu cadw''r lwfans yn ei le tan {0}, ni fydd yn rhaid i''ch cyn-bartner dalu unrhyw dreth.
-change.status.divorce.transferor.option2	=	Os ydych yn dewis dod ag ef i ben o {0}, efallai na fydd eich cyn-bartner wedi talu digon o dreth a bydd yn rhaid iddo dalu''r dreth honno. Byddwn yn casglu unrhyw dreth sydd arno drwy addasu''i god treth.
-change.status.divorce.transferor.keep	=	A hoffech gadw''ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth?
-change.status.divorce.transferor.eoy-yes	=	Bydd eich Lwfans Priodasol yn parhau tan ddiwedd y flwyddyn dreth hon ({0}). Bydd eich Lwfans Personol yn cael ei addasu ar ddechrau''r flwyddyn dreth newydd ar {1}.
+change.status.divorce.transferor.conditional1.para4	=	os nad yw’ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu’i god treth
+change.status.divorce.transferor.conditional2.para2	=	Gallwch gadw’ch Lwfans Priodasol tan {0}, sef diwedd y flwyddyn dreth pan wnaethoch ysgaru. Bydd eich Lwfans Priodasol yn cael ei ddileu o {1}, sef dechrau’r flwyddyn dreth bresennol ymlaen.
+change.status.divorce.transferor.conditional2.para3	=	Rhown wybod i chi os ydych wedi talu’r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Os nad ydych wedi talu digon, byddwn yn ei chasglu drwy addasu’ch cod treth.
+change.status.divorce.transferor.option1	=	Os ydych yn penderfynu cadw’r lwfans yn ei le tan {0}, ni fydd yn rhaid i’ch cyn-bartner dalu unrhyw dreth.
+change.status.divorce.transferor.option2	=	Os ydych yn dewis dod ag ef i ben o {0}, efallai na fydd eich cyn-bartner wedi talu digon o dreth a bydd yn rhaid iddo dalu’r dreth honno. Byddwn yn casglu unrhyw dreth sydd arno drwy addasu’i god treth.
+change.status.divorce.transferor.keep	=	A hoffech gadw’ch Lwfans Priodasol tan ddiwedd y flwyddyn dreth?
+change.status.divorce.transferor.eoy-yes	=	Bydd eich Lwfans Priodasol yn parhau tan ddiwedd y flwyddyn dreth hon ({0}). Bydd eich Lwfans Personol yn cael ei addasu ar ddechrau’r flwyddyn dreth newydd ar {1}.
 change.status.divorce.transferor.eoy-no	=	Bydd eich Lwfans Priodasol yn dod i ben o {0} ymlaen.<br><p>Gallai hyn arwain at eich cyn-bartner yn gorfod ad-dalu unrhyw dreth sydd arno.</p>
 change.status.divorce.recipient.para1	=	bydd eich Lwfans Priodasol yn cael ei ddileu o {0}, sef diwedd y flwyddyn dreth bresennol
 change.status.divorce.recipient.previous.para1	=	bydd eich Lwfans Priodasol yn cael ei ganslo o {0} ymlaen
-change.status.divorce.recipient.previous.para2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu''ch cod treth
+change.status.divorce.recipient.previous.para2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu’ch cod treth
 change.status.divorce.recipient.content1	=	Gan fod y dyddiad hwn yn ystod y flwyddyn dreth bresennol:
-change.status.divorce.recipient.options	=	Ar &#244;l i chi roi gwybod i ni, bydd eich Lwfans Priodasol yn aros yn ei le tan ddiwedd y flwyddyn dreth ({0}). Ni fydd CThEM yn gofyn i chi ad-dalu''r lwfans ychwanegol hwn.
-change.status.divorce.recipient.directions	=	Dylech roi gwybod i ni os ydych wedi ysgaru ac mae gennych <a href="{0}">archddyfarniad absoliwt</a>, neu os yw''ch partneriaeth sifil wedi dod i ben ac mae gennych <a href="{1}">orchymyn terfynol</a>. Dyma''r dogfennau sy''n dod &#226;''ch priodas neu''ch partneriaeth sifil i ben yn gyfreithlon.
-change.status.historic-active.result	=	Gallai dileu Lwfans Priodasol o ddechrau''r flwyddyn dreth arwain at eich partner yn tandalu treth. Rhown wybod iddo ar ddiwedd y flwyddyn dreth. Bydd unrhyw dandaliad fel arfer yn cael ei gasglu drwy addasu''i god treth.
-change.status.historic-active.directions	=	Gallwch ddileu Lwfans Priodasol o ddechrau''r flwyddyn dreth ({2}) os ydych wedi ysgaru ac mae gennych <a href="{0}">archddyfarniad absoliwt</a>, neu os yw''ch partneriaeth sifil wedi dod i ben ac mae gennych <a href="{1}">orchymyn terfynol</a>. Dyma''r dogfennau sy''n dod &#226;''ch priodas neu''ch partneriaeth sifil i ben yn gyfreithlon.
+change.status.divorce.recipient.options	=	Ar &#244;l i chi roi gwybod i ni, bydd eich Lwfans Priodasol yn aros yn ei le tan ddiwedd y flwyddyn dreth ({0}). Ni fydd CThEM yn gofyn i chi ad-dalu’r lwfans ychwanegol hwn.
+change.status.divorce.recipient.directions	=	Dylech roi gwybod i ni os ydych wedi ysgaru ac mae gennych <a href="{0}">archddyfarniad absoliwt</a>, neu os yw’ch partneriaeth sifil wedi dod i ben ac mae gennych <a href="{1}">orchymyn terfynol</a>. Dyma’r dogfennau sy’n dod &#226;’ch priodas neu’ch partneriaeth sifil i ben yn gyfreithlon.
+change.status.historic-active.result	=	Gallai dileu Lwfans Priodasol o ddechrau’r flwyddyn dreth arwain at eich partner yn tandalu treth. Rhown wybod iddo ar ddiwedd y flwyddyn dreth. Bydd unrhyw dandaliad fel arfer yn cael ei gasglu drwy addasu’i god treth.
+change.status.historic-active.directions	=	Gallwch ddileu Lwfans Priodasol o ddechrau’r flwyddyn dreth ({2}) os ydych wedi ysgaru ac mae gennych <a href="{0}">archddyfarniad absoliwt</a>, neu os yw’ch partneriaeth sifil wedi dod i ben ac mae gennych <a href="{1}">orchymyn terfynol</a>. Dyma’r dogfennau sy’n dod &#226;’ch priodas neu’ch partneriaeth sifil i ben yn gyfreithlon.
 change.status.cancel.h1	=	Canslo Lwfans Priodasol
 
-change.status.cancel.content	=	Byddwn yn canslo''ch Lwfans Priodasol, ond bydd yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol.
-change.status.cancel.content1	=	Bydd eich Lwfans Priodasol yn dychwelyd i''r swm blaenorol o {0}, sef dechrau''r flwyddyn dreth newydd. Ni fydd yn rhaid i''ch partner ad-dalu unrhyw dreth.
+change.status.cancel.content	=	Byddwn yn canslo’ch Lwfans Priodasol, ond bydd yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol.
+change.status.cancel.content1	=	Bydd eich Lwfans Priodasol yn dychwelyd i’r swm blaenorol o {0}, sef dechrau’r flwyddyn dreth newydd. Ni fydd yn rhaid i’ch partner ad-dalu unrhyw dreth.
 change.status.reject.h1	=	Dileu cais blaenorol am Lwfans Priodasol
-change.status.reject.content	=	Caiff eich Lwfans Priodasol ei ganslo o {0} ymlaen, sef dechrau''r flwyddyn dreth pan gawsoch ef am y tro cyntaf.
-change.status.reject.warning	=	Gallai hyn arwain at beidio &#226; thalu digon o dreth. Rhown wybod i chi a ydych wedi talu''r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Os nad ydych wedi talu digon, fel arfer byddwn yn ei chasglu drwy addasu''ch cod treth.
-change.status.reject.previous.content	=	Gallwch ddileu''r Lwfans Priodasol y gwnaethoch ei hawlio''n flaenorol. Caiff y lwfans ei ddileu o {0}, sef dechrau''r flwyddyn dreth pan gawsoch ef am y tro cyntaf.
-change.status.reject.previous.warning	=	Gallai hyn arwain at dandalu treth. Rhown wybod i chi a ydych wedi talu''r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Fel arfer, bydd unrhyw dandaliad yn cael ei gasglu drwy addasu''ch cod treth.
+change.status.reject.content	=	Caiff eich Lwfans Priodasol ei ganslo o {0} ymlaen, sef dechrau’r flwyddyn dreth pan gawsoch ef am y tro cyntaf.
+change.status.reject.warning	=	Gallai hyn arwain at beidio &#226; thalu digon o dreth. Rhown wybod i chi a ydych wedi talu’r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Os nad ydych wedi talu digon, fel arfer byddwn yn ei chasglu drwy addasu’ch cod treth.
+change.status.reject.previous.content	=	Gallwch ddileu’r Lwfans Priodasol y gwnaethoch ei hawlio’n flaenorol. Caiff y lwfans ei ddileu o {0}, sef dechrau’r flwyddyn dreth pan gawsoch ef am y tro cyntaf.
+change.status.reject.previous.warning	=	Gallai hyn arwain at dandalu treth. Rhown wybod i chi a ydych wedi talu’r swm cywir o dreth ar ddiwedd y flwyddyn dreth. Fel arfer, bydd unrhyw dandaliad yn cael ei gasglu drwy addasu’ch cod treth.
 change.status.allowance	=	Statws y lwfans
 change.status.realtionship-end	=	Rheswm dros ganslo
 change.status.confirm-removal.button	=	Cadarnhau dileu
-change.status.divorce-cy-heading	=	Dileu''r trosglwyddiad Lwfans Priodasol hwn
+change.status.divorce-cy-heading	=	Dileu’r trosglwyddiad Lwfans Priodasol hwn
 change.status.divorce-cy-content	=	Bydd hyn yn cael ei ddileu ar ddiwedd y flwyddyn dreth bresennol, sef Ebrill 5 {0}.
 change.status.cancel-your.h1	=	Canslo Lwfans Priodasol
-change.status.cancel-your.p	=	Pam yr ydych am ganslo''ch Lwfans Priodasol?
+change.status.cancel-your.p	=	Pam yr ydych am ganslo’ch Lwfans Priodasol?
 change.status.confirm.email	=	Nodwch eich cyfeiriad e-bost i gadarnhau
 change.status.history.h4	=	Eich ceisiadau am Lwfans Priodasol
 change.status.start-date	=	Dyddiad dechrau
@@ -413,105 +413,105 @@ change.status.history.reason	=	Rheswm dros newid
 change.status.active	=	Gweithredol
 change.status.active.present.year	=	i Presennol
 change.status.active.to	=	–
-change.status.transferor.amount	=	Byddwch yn rhoi''r gorau i drosglwyddo Lwfans Priodasol i''ch priod neu bartner sifil ddiwedd blwyddyn dreth ({0}).
-change.status.receiving.amount	=	Byddwch yn rhoi''r gorau i gael Lwfans Priodasol gan eich priod neu bartner sifil ddiwedd blwyddyn dreth ({0}).
-change.status.transferor.stop-sooner	=	Gallwch ddod &#226;''ch trosglwyddiad Lwfans Priodasol i ben yn gynharach.
+change.status.transferor.amount	=	Byddwch yn rhoi’r gorau i drosglwyddo Lwfans Priodasol i’ch priod neu bartner sifil ddiwedd blwyddyn dreth ({0}).
+change.status.receiving.amount	=	Byddwch yn rhoi’r gorau i gael Lwfans Priodasol gan eich priod neu bartner sifil ddiwedd blwyddyn dreth ({0}).
+change.status.transferor.stop-sooner	=	Gallwch ddod &#226;’ch trosglwyddiad Lwfans Priodasol i ben yn gynharach.
 change.status.recipient.stop-sooner	=	Gallwch beidio &#226; chael Lwfans Priodasol yn gynharach.
 change.status.finish.divorce	=	Ysgariad yn llwyddiannus
 
 cchange.status.finish.will-be-current	=	Caiff eich Lwfans Priodasol ei ddileu ar ddiwedd y flwyddyn dreth bresennol.
-change.status.finish.will-be-next	=	Bydd eich Lwfans Priodasol yn cael ei ddileu o ddechrau''r flwyddyn dreth bresennol ymlaen.
+change.status.finish.will-be-next	=	Bydd eich Lwfans Priodasol yn cael ei ddileu o ddechrau’r flwyddyn dreth bresennol ymlaen.
 change.status.apply	=	Gwneud cais am Lwfans Priodasol
 change.status.have-not-applied	=	Nid ydych yn elwa o Lwfans Priodasol ar hyn o bryd.
-change.status.ask-to-check	=	Os ydych yn briod neu mewn partneriaeth sifil, efallai y gallwch drosglwyddo rhywfaint o''ch Lwfans Personol di-dreth i''ch partner. Gwiriwch a ydych yn gymwys i wneud cais am Lwfans Priodasol.
-change.status.bereavement.sorry	=	Mae''n ddrwg gennym am eich colled
+change.status.ask-to-check	=	Os ydych yn briod neu mewn partneriaeth sifil, efallai y gallwch drosglwyddo rhywfaint o’ch Lwfans Personol di-dreth i’ch partner. Gwiriwch a ydych yn gymwys i wneud cais am Lwfans Priodasol.
+change.status.bereavement.sorry	=	Mae’n ddrwg gennym am eich colled
 change.status.bereavement.notify-hmrc	=	Gallwch roi gwybod i CThEM am brofedigaeth ar:
-change.status.bereavement.rec.instruction	=	Os trosglwyddodd eich partner rywfaint o''i Lwfans Personol i chi cyn iddo farw:
+change.status.bereavement.rec.instruction	=	Os trosglwyddodd eich partner rywfaint o’i Lwfans Personol i chi cyn iddo farw:
 change.status.bereavement.rec.instruction-1	=	bydd eich Lwfans Personol yn parhau ar y lefel uchaf tan ddiwedd y flwyddyn dreth (5 Ebrill)
 change.status.bereavement.rec.instruction-2	=	caiff ei yst&#226;d ei drin fel bod ei Lwfans Personol yn llai, am ei fod wedi trosglwyddo ychydig ohono i chi
-change.status.bereavement.tr.instruction	=	Os yw''ch partner yn marw ar &#244;l i chi drosglwyddo rhywfaint o''ch Lwfans Personol iddo:
-change.status.bereavement.tr.instruction-1	=	caiff ei yst&#226;d ei drin fel bod ganddo''r Lwfans Personol ychwanegol y gwnaethoch drosglwyddo iddo
-change.status.bereavement.tr.instruction-2	=	bydd eich Lwfans Personol yn dychwelyd i''r swm arferol ar ddiwedd y flwyddyn dreth (5 Ebrill)
+change.status.bereavement.tr.instruction	=	Os yw’ch partner yn marw ar &#244;l i chi drosglwyddo rhywfaint o’ch Lwfans Personol iddo:
+change.status.bereavement.tr.instruction-1	=	caiff ei yst&#226;d ei drin fel bod ganddo’r Lwfans Personol ychwanegol y gwnaethoch drosglwyddo iddo
+change.status.bereavement.tr.instruction-2	=	bydd eich Lwfans Personol yn dychwelyd i’r swm arferol ar ddiwedd y flwyddyn dreth (5 Ebrill)
 change.status.divorce.radio	=	Ysgariad neu ddiwedd partneriaeth sifil
 change.status.bereavement.radio	=	Profedigaeth
-change.status.earnings.radio	=	Newid i''ch incwm
-change.status.cancel.radio	=	Rwyf am roi''r gorau i gael taliadau Lwfans Priodasol
+change.status.earnings.radio	=	Newid i’ch incwm
+change.status.cancel.radio	=	Rwyf am roi’r gorau i gael taliadau Lwfans Priodasol
 change.status.confirm-change	=	Cadarnhewch eich bod am newid y trosglwyddiad Lwfans Priodasol hwn.
-change.status.previous-years	=	Rydym wedi sylwi y gallech wneud cais am Lwfans Priodasol ar gyfer blynyddoedd treth blaenorol. Os ydych yn gymwys, byddwn yn ei &#244;l-ddyddio ac yn anfon siec at eich partner drwy''r post.
+change.status.previous-years	=	Rydym wedi sylwi y gallech wneud cais am Lwfans Priodasol ar gyfer blynyddoedd treth blaenorol. Os ydych yn gymwys, byddwn yn ei &#244;l-ddyddio ac yn anfon siec at eich partner drwy’r post.
 confirm.transferor.heading	=	Cadarnhau canslo Lwfans Priodasol
 confirm.recipient.ended.reject.heading	=	Cadarnhau dileu cais blaenorol am Lwfans Priodasol
-pages.ended.reject.message	=	Rydych wedi gofyn i ni ddileu''ch Lwfans Priodasol o flwyddyn dreth {0} ymlaen. Mae hyn yn golygu:
-pages.ended.reject.message1	=	caiff eich Lwfans Priodasol ei ddileu o {0} ymlaen, sef dechrau''r flwyddyn dreth pan gawsoch ef am y tro cyntaf
-pages.ended.reject.message2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu''ch cod treth
-pages.confirm.message	=	Rydych wedi gofyn i ni ganslo''ch Lwfans Priodasol. Mae hyn yn golygu:
+pages.ended.reject.message	=	Rydych wedi gofyn i ni ddileu’ch Lwfans Priodasol o flwyddyn dreth {0} ymlaen. Mae hyn yn golygu:
+pages.ended.reject.message1	=	caiff eich Lwfans Priodasol ei ddileu o {0} ymlaen, sef dechrau’r flwyddyn dreth pan gawsoch ef am y tro cyntaf
+pages.ended.reject.message2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu’ch cod treth
+pages.confirm.message	=	Rydych wedi gofyn i ni ganslo’ch Lwfans Priodasol. Mae hyn yn golygu:
 pages.confirm.message1	=	bydd eich Lwfans Priodasol yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol
-pages.confirm.message2	=	bydd eich Lwfans Personol yn dychwelyd i''r swm arferol o {0} ymlaen, sef dechrau''r flwyddyn dreth newydd
-pages.reject.message1	=	caiff eich Lwfans Priodasol ei ganslo o {0} ymlaen, sef dechrau''r flwyddyn dreth pan gawsoch ef am y tro cyntaf
-pages.reject.message2	=	byddwn yn rhoi gwybod i chi ar ddiwedd y flwyddyn dreth a ydych wedi talu''r swm cywir o dreth
-pages.reject.message3	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu''ch cod treth
+pages.confirm.message2	=	bydd eich Lwfans Personol yn dychwelyd i’r swm arferol o {0} ymlaen, sef dechrau’r flwyddyn dreth newydd
+pages.reject.message1	=	caiff eich Lwfans Priodasol ei ganslo o {0} ymlaen, sef dechrau’r flwyddyn dreth pan gawsoch ef am y tro cyntaf
+pages.reject.message2	=	byddwn yn rhoi gwybod i chi ar ddiwedd y flwyddyn dreth a ydych wedi talu’r swm cywir o dreth
+pages.reject.message3	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu’ch cod treth
 confirm.cancellation.button	=	Cadarnhau canslo
-pages.confirm.divorce.cy.message	=	Rydych wedi gofyn i ni gadw''ch Lwfans Priodasol yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol. Mae hyn yn golygu:
-pages.confirm.divorce.cy.message1	=	bydd eich Lwfans Personol yn dychwelyd i''r swm arferol o {0} ymlaen, sef dechrau''r flwyddyn dreth newydd
-pages.confirm.divorce.cy.prev.message	=	Rydych wedi gofyn i ni ganslo''ch Lwfans Priodasol. Mae hyn yn golygu:
+pages.confirm.divorce.cy.message	=	Rydych wedi gofyn i ni gadw’ch Lwfans Priodasol yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol. Mae hyn yn golygu:
+pages.confirm.divorce.cy.message1	=	bydd eich Lwfans Personol yn dychwelyd i’r swm arferol o {0} ymlaen, sef dechrau’r flwyddyn dreth newydd
+pages.confirm.divorce.cy.prev.message	=	Rydych wedi gofyn i ni ganslo’ch Lwfans Priodasol. Mae hyn yn golygu:
 pages.confirm.divorce.cy.prev.message1	=	bydd eich lwfans yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth pan wnaethoch ysgaru
-pages.confirm.divorce.cy.prev.message2	=	os nad yw''ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu''i god treth
-pages.confirm.divorce.py.message	=	Rydych wedi gofyn i ni ganslo''ch Lwfans Priodasol o {0} ymlaen, sef dechrau''r flwyddyn dreth bresennol. Mae hyn yn golygu:
-pages.confirm.divorce.py.message1	=	os nad yw''ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu''i god treth
-pages.confirm.divorce.py.message2	=	bydd eich Lwfans Personol yn dychwelyd i''r swm arferol o {0} ymlaen, sef dechrau''r flwyddyn dreth bresennol
+pages.confirm.divorce.cy.prev.message2	=	os nad yw’ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu’i god treth
+pages.confirm.divorce.py.message	=	Rydych wedi gofyn i ni ganslo’ch Lwfans Priodasol o {0} ymlaen, sef dechrau’r flwyddyn dreth bresennol. Mae hyn yn golygu:
+pages.confirm.divorce.py.message1	=	os nad yw’ch cyn-bartner wedi talu digon o dreth, byddwn yn ei chasglu drwy addasu’i god treth
+pages.confirm.divorce.py.message2	=	bydd eich Lwfans Personol yn dychwelyd i’r swm arferol o {0} ymlaen, sef dechrau’r flwyddyn dreth bresennol
 pages.confirm.recipient.divorce.cy.prev.message1	=	caiff eich Lwfans Priodasol ei ganslo o {0} ymlaen, sef diwedd y flwyddyn dreth pan wnaethoch ysgaru
-pages.confirm.recipient.divorce.cy.prev.message2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu''ch cod treth
+pages.confirm.recipient.divorce.cy.prev.message2	=	os nad ydych wedi talu digon o dreth, fel arfer byddwn yn ei chasglu drwy addasu’ch cod treth
 pages.confirm.recipient.divorce.cy.message1	=	bydd eich Lwfans Priodasol yn aros yn ei le tan {0}, sef diwedd y flwyddyn dreth bresennol
-pages.confirm.recipient.divorce.cy.message2	=	bydd eich Lwfans Personol yn dychwelyd i''r swm arferol o {0} ymlaen, sef dechrau''r flwyddyn dreth newydd
+pages.confirm.recipient.divorce.cy.message2	=	bydd eich Lwfans Personol yn dychwelyd i’r swm arferol o {0} ymlaen, sef dechrau’r flwyddyn dreth newydd
 
 #application errors
 pages.form.error-header	=	Mae problem wedi codi
-pages.errors.timeout-pta.header	=	Rydych wedi allgofnodi o''ch Cyfrif Treth Personol.
-pages.errors.timeout-pta.action	=	Mewngofnodwch i''ch Cyfrif Treth Personol eto i wneud cais am Lwfans Priodasol.
-pages.errors.timeout-pta.back	=	Yn &#244;l i''r Cyfrif Treth Personol
+pages.errors.timeout-pta.header	=	Rydych wedi allgofnodi o’ch Cyfrif Treth Personol.
+pages.errors.timeout-pta.action	=	Mewngofnodwch i’ch Cyfrif Treth Personol eto i wneud cais am Lwfans Priodasol.
+pages.errors.timeout-pta.back	=	Yn &#244;l i’r Cyfrif Treth Personol
 pages.form.error.confirm.data	=	Gwiriwch fod eich gwybodaeth yn gywir, yn y man cywir ac yn y fformat cywir.
 pages.form.error.mandatory.data	=	Gwiriwch eich bod wedi rhoi atebion.
 transferor.not.found	=	Ni allwn ddod o hyd i gofnod CThEM ar eich cyfer.
-recipient.not.found.para1	=	Ni allwn ddod o hyd i gofnod CThEM ar gyfer eich priod neu''ch partner sifil.
-recipient.not.found.para2	=	Gwiriwch gydag ef/hi a chadarnhau''r manylion yr ydych wedi eu rhoi.
-transferor.no-eligible-years	=	Nid oeddem yn gallu prosesu''ch cais am Lwfans Priodasol.
-transferor.no-previous-years-available	=	Yn seiliedig ar ddyddiad y briodas neu ffurfio''r bartneriaeth sifil yr ydych wedi''i roi, nid ydych yn gymwys ar gyfer Lwfans Priodasol.
-recipient.has.relationship.para1	=	Nid oeddem yn gallu prosesu''ch cais.
-recipient.has.relationship.para2	=	Gwiriwch &#226;''ch priod neu''ch partner sifil a chadarnhau''r manylion yr ydych wedi''u rhoi.
+recipient.not.found.para1	=	Ni allwn ddod o hyd i gofnod CThEM ar gyfer eich priod neu’ch partner sifil.
+recipient.not.found.para2	=	Gwiriwch gydag ef/hi a chadarnhau’r manylion yr ydych wedi eu rhoi.
+transferor.no-eligible-years	=	Nid oeddem yn gallu prosesu’ch cais am Lwfans Priodasol.
+transferor.no-previous-years-available	=	Yn seiliedig ar ddyddiad y briodas neu ffurfio’r bartneriaeth sifil yr ydych wedi’i roi, nid ydych yn gymwys ar gyfer Lwfans Priodasol.
+recipient.has.relationship.para1	=	Nid oeddem yn gallu prosesu’ch cais.
+recipient.has.relationship.para2	=	Gwiriwch &#226;’ch priod neu’ch partner sifil a chadarnhau’r manylion yr ydych wedi’u rhoi.
 session.timeout.button	=	Dechrau eto
-session.timeout.statement	=	Mae''ch sesiwn wedi cyrraedd y terfyn amser
-session.timeout.verbose-statement	=	Mae''r system wedi''ch allgofnodi o Lwfans Priodasol.
+session.timeout.statement	=	Mae’ch sesiwn wedi cyrraedd y terfyn amser
+session.timeout.verbose-statement	=	Mae’r system wedi’ch allgofnodi o Lwfans Priodasol.
 create.relationship.failure	=	Ni ellir creu perthynas
-not.authorised	=	Mae''n ddrwg gennym. Nid oes gennych yr awdurdod i fynd yn eich blaen.
+not.authorised	=	Mae’n ddrwg gennym. Nid oes gennych yr awdurdod i fynd yn eich blaen.
 technical.issue.para1	=	Mae problemau technegol wedi codi
 technical.issue.para2	=	Mae problemau technegol wedi codi. Rhowch gynnig arall arni mewn ychydig o funudau.
 technical.issue.back	=	Dychwelyd i GOV.UK
 technical.other-ways.h1	=	Ffyrdd eraill o wneud cais am Lwfans Priodasol
 technical.other-ways.para1	=	Nid oeddem yn gallu cadarnhau pwy ydych ar-lein. Ffoniwch Gyllid a Thollau EM (CThEM) i wneud cais am Lwfans Priodasol.
-technical.other-ways.para2	=	Bydd angen i chi wybod beth yw''ch rhif Yswiriant Gwladol chi a''ch priod neu bartner sifil pan fyddwch yn ffonio.
+technical.other-ways.para2	=	Bydd angen i chi wybod beth yw’ch rhif Yswiriant Gwladol chi a’ch priod neu bartner sifil pan fyddwch yn ffonio.
 title.cannot-find-details	=	Methu dod o hyd i fanylion
 title.technical-error	=	Problem dechnegol
 technical.cannot-find-details.h1	=	Ni allwn ddod o hyd i fanylion eich Lwfans Priodasol
 technical.cannot-find-details.para1	=	Ffoniwch ni er mwyn newid eich Lwfans Priodasol. Sicrhewch fod gennych eich rhif Yswiriant Gwladol wrth law pan fyddwch yn ffonio
 technical.technical-error.h1	=	Mae problem dechnegol wedi codi
-technical.technical-error.para1	=	Rhowch gynnig arall arni. Os yw''r broblem yn parhau, ffoniwch ni er mwyn newid eich Lwfans Priodasol. Sicrhewch fod gennych eich rhif Yswiriant Gwladol wrth law pan fyddwch yn ffonio.
+technical.technical-error.para1	=	Rhowch gynnig arall arni. Os yw’r broblem yn parhau, ffoniwch ni er mwyn newid eich Lwfans Priodasol. Sicrhewch fod gennych eich rhif Yswiriant Gwladol wrth law pan fyddwch yn ffonio.
 
-generic.translation.text	=	Mae''r dudalen hon hefyd ar gael yn
+generic.translation.text	=	Mae’r dudalen hon hefyd ar gael yn
 generic.translation.english	=	English
 generic.translation.welsh	=	Cymraeg
 radio.yes	=	Iawn
 radio.no	=	Na
 
 #history page
-pages.history.help.partner	=	Ar hyn o bryd, rydych yn helpu''ch partner i elwa o Lwfans Priodasol.
-pages.history.helped.by.partner	=	Ar hyn o bryd, mae''ch partner yn eich helpu i elwa o Lwfans Priodasol.
+pages.history.help.partner	=	Ar hyn o bryd, rydych yn helpu’ch partner i elwa o Lwfans Priodasol.
+pages.history.helped.by.partner	=	Ar hyn o bryd, mae’ch partner yn eich helpu i elwa o Lwfans Priodasol.
 pages.history.cancellation	=	Gallwch ganslo Lwfans Priodasol ar-lein
-pages.history.cancellation1	=	Os ydych wedi ysgaru neu wedi dod &#226;''ch partneriaeth sifil i ben, gallwch ganslo''ch Lwfans Priodasol ar-lein. Os ydych wedi ymwahanu &#226;''ch priod neu bartner sifil ar hyn o bryd, gallwch barhau i gael Lwfans Priodasol hyd nes eich bod yn dod &#226;''ch priodas neu bartneriaeth sifil i ben yn gyfreithlon.
+pages.history.cancellation1	=	Os ydych wedi ysgaru neu wedi dod &#226;’ch partneriaeth sifil i ben, gallwch ganslo’ch Lwfans Priodasol ar-lein. Os ydych wedi ymwahanu &#226;’ch priod neu bartner sifil ar hyn o bryd, gallwch barhau i gael Lwfans Priodasol hyd nes eich bod yn dod &#226;’ch priodas neu bartneriaeth sifil i ben yn gyfreithlon.
 pages.history.cancellation2	=	Gallwch hefyd ganslo er mwyn dod &#226; thaliadau i ben os ydych yn dal i fod yn briod neu mewn partneriaeth sifil, ond nad ydych bellach am elwa o Lwfans Priodasol.
 
-pages.history.partner.help	=	Ar hyn o bryd, mae''ch partner yn eich helpu i elwa o Lwfans Priodasol.
+pages.history.partner.help	=	Ar hyn o bryd, mae’ch partner yn eich helpu i elwa o Lwfans Priodasol.
 pages.history.cancel	=	Gallwch ganslo Lwfans Priodasol:
-pages.history.cancel1	=	os ydych wedi ysgaru neu ddod &#226;''ch partneriaeth sifil i ben
-pages.history.cancel2	=	os yw''ch incwm wedi newid
+pages.history.cancel1	=	os ydych wedi ysgaru neu ddod &#226;’ch partneriaeth sifil i ben
+pages.history.cancel2	=	os yw’ch incwm wedi newid
 pages.history.cancel3	=	os ydych am wrthod y lwfans
 pages.history.cancel4	=	os ydych wedi dioddef profedigaeth
 pages.history.button.remove	=	Dileu lwfans
@@ -522,7 +522,7 @@ pages.eligibleyear.toldus	=	Rhoesoch wybod y gwnaethoch briodi neu ffurfio partn
 pages.eligibleyear.thisyear	=	Yn ystod y flwyddyn dreth bresennol</span><br>{0} ymlaen
 pages.eligibleyear.li1	=	bydd {0} yn talu hyd at £{1} yn llai o dreth bob blwyddyn
 pages.eligibleyear.li2	=	byddwn yn addasu cod treth <span id="firstNameOnly3">{0}</span> i gynnwys y lwfans ychwanegol hwn
-pages.eligibleyear.li3	=	bydd yn adnewyddu''n awtomatig bob blwyddyn oni bai''ch bod chi neu <span id="firstNameOnly4">{0}</span> yn ei ganslo neu <a href="https://www.gov.uk/marriage-allowance-guide/if-your-circumstances-change">nad ydych bellach yn gymwys</a>
+pages.eligibleyear.li3	=	bydd yn adnewyddu’n awtomatig bob blwyddyn oni bai’ch bod chi neu <span id="firstNameOnly4">{0}</span> yn ei ganslo neu <a href="https://www.gov.uk/marriage-allowance-guide/if-your-circumstances-change">nad ydych bellach yn gymwys</a>
 pages.eligibleyear.doyou.want	=	A ydych am wneud cais ar gyfer y flwyddyn dreth bresennol ymlaen?
 pages.eligibleyear.notice	=	Gallwch wneud cais ar gyfer blynyddoedd cynharach os ydych yn mynd yn eich blaen.
 
@@ -530,44 +530,44 @@ pages.eligibleyear.notice	=	Gallwch wneud cais ar gyfer blynyddoedd cynharach os
 #multi-year
 pages.multiyear.taxyear	=	Blwyddyn dreth {0}
 pages.multiyear.canclaim	=	Gallwch chi a <span id="firstNameOnly">{0}</span> wneud cais am Lwfans Priodasol ar gyfer blwyddyn dreth {1}:
-pages.multiyear.successful	=	Os yw''ch cais yn llwyddiannus, bydd Lwfans Priodasol yn cael ei &#244;l-ddyddio ar gyfer blwyddyn dreth {0} a bydd <span id="firstNameOnly3"> {1} </span> yn cael siec am hyd at {2}.
+pages.multiyear.successful	=	Os yw’ch cais yn llwyddiannus, bydd Lwfans Priodasol yn cael ei &#244;l-ddyddio ar gyfer blwyddyn dreth {0} a bydd <span id="firstNameOnly3"> {1} </span> yn cael siec am hyd at {2}.
 pages.multiyear.extrayears	=	A hoffech wneud cais ar gyfer y flwyddyn dreth ychwanegol hon hefyd?
 
 #previous-years
 pages.previousyear.header	=	Gallwch wneud cais ar gyfer blynyddoedd treth blaenorol
-pages.previousyear.lede	=	Gallwch wneud cais am Lwfans Priodasol o''r adeg pan gafodd ei gyflwyno am y tro cyntaf, sef 6 Ebrill 2015.
+pages.previousyear.lede	=	Gallwch wneud cais am Lwfans Priodasol o’r adeg pan gafodd ei gyflwyno am y tro cyntaf, sef 6 Ebrill 2015.
 pages.previousyear.para	=	Rhoesoch wybod y gwnaethoch briodi neu ffurfio partneriaeth sifil gyda <span id="firstNameOnly">{0}</span> ar <span id="marriageDate">{1}</span>. Mae hyn yn golygu y gallwch wneud cais ar gyfer blynyddoedd treth blaenorol.
 
 #confirm-page
-pages.confirm.lower.earner	=	Eich manylion (yr unigolyn &#226;''r cyflog isaf)
-pages.confirm.higher.earner	=	Manylion eich partner (yr unigolyn &#226;''r cyflog uchaf)
+pages.confirm.lower.earner	=	Eich manylion (yr unigolyn &#226;’r cyflog isaf)
+pages.confirm.higher.earner	=	Manylion eich partner (yr unigolyn &#226;’r cyflog uchaf)
 pages.confirm.current.tax	=	Blwyddyn dreth bresennol: {0} ymlaen
-pages.confirm.current.tax.desc	=	Bydd CThEM yn newid codau treth chi a {0} er mwyn arbed {1} hyd at £{2}. Bydd eich Lwfans Priodasol yn parhau''n awtomatig oni bai''ch bod chi neu {3} yn ei ganslo, neu nad ydych bellach yn gymwys fel p&#226;r.
+pages.confirm.current.tax.desc	=	Bydd CThEM yn newid codau treth chi a {0} er mwyn arbed {1} hyd at £{2}. Bydd eich Lwfans Priodasol yn parhau’n awtomatig oni bai’ch bod chi neu {3} yn ei ganslo, neu nad ydych bellach yn gymwys fel p&#226;r.
 pages.confirm.previous.tax	=	Blwyddyn dreth flaenorol: {0} i {1}
-pages.confirm.previous.tax.desc	=	Bydd CThEM yn gwirio''r manylion yr ydych wedi''u rhoi cyn anfon siec at {0} drwy''r post am hyd at {1}.
-pages.confirm.warning	=	Dylech wirio''r manylion yr ydych wedi''u rhoi a sicrhau mai dyma''r person yr hoffech wneud cais am Lwfans Priodasol gydag ef/hi.
-pages.confirm.button	=	Cadarnhau''ch cais
+pages.confirm.previous.tax.desc	=	Bydd CThEM yn gwirio’r manylion yr ydych wedi’u rhoi cyn anfon siec at {0} drwy’r post am hyd at {1}.
+pages.confirm.warning	=	Dylech wirio’r manylion yr ydych wedi’u rhoi a sicrhau mai dyma’r person yr hoffech wneud cais am Lwfans Priodasol gydag ef/hi.
+pages.confirm.button	=	Cadarnhau’ch cais
 pages.confirm.marriage.details	=	Manylion eich Lwfans Priodasol
-pages.confirm.date.of.marriage	=	Dyddiad y briodas neu ffurfio''r bartneriaeth sifil
+pages.confirm.date.of.marriage	=	Dyddiad y briodas neu ffurfio’r bartneriaeth sifil
 
 #change-of-circs-finish-page
-pages.coc.finish.header	=	Lwfans Priodasol wedi''i ganslo
+pages.coc.finish.header	=	Lwfans Priodasol wedi’i ganslo
 pages.coc.finish.acknowledgement	=	Anfonir e-bost atoch yn <strong>{0}</strong> i gydnabod y canslo, a hynny o <strong>noreply&#64;tax.service.gov.uk</strong> cyn pen 24 awr.
-pages.coc.finish.junk	=	Os nad yw''n ymddangos yn eich mewnflwch, edrychwch yn eich ffolder sbam neu sothach.
-pages.coc.finish.whn	=	Yr hyn sy''n digwydd nesaf
-pages.coc.finish.para1	=	Bydd y canslo''n cael ei brosesu gan CThEM. Am fanylion llawn, edrychwch ar yr e-bost yr ydym wedi''i anfon atoch.
+pages.coc.finish.junk	=	Os nad yw’n ymddangos yn eich mewnflwch, edrychwch yn eich ffolder sbam neu sothach.
+pages.coc.finish.whn	=	Yr hyn sy’n digwydd nesaf
+pages.coc.finish.para1	=	Bydd y canslo’n cael ei brosesu gan CThEM. Am fanylion llawn, edrychwch ar yr e-bost yr ydym wedi’i anfon atoch.
 pages.coc.finish.para2	=	Nid oes angen i chi gysylltu &#226; ni. Gallwch <a href="history">wirio statws</a> eich Lwfans Priodasol ar-lein.
 
 date.fields.day	=	Diwrnod
 date.fields.month	=	Mis
 date.fields.year	=	Blwyddyn
 
-change.other.caption	=	Newidiadau eraill sy''n effeithio ar Lwfans Priodasol
+change.other.caption	=	Newidiadau eraill sy’n effeithio ar Lwfans Priodasol
 change.other.sub.caption1	=	Newid mewn incwm
-change.other.income.content	=	Er mwyn elwa o Lwfans Priodasol fel p&#226;r, dylech ennill £{0} neu lai''r flwyddyn. Er mwyn bod yn gymwys, mae''n rhaid i''ch partner ennill rhwng £{1} a £{2} y flwyddyn.
+change.other.income.content	=	Er mwyn elwa o Lwfans Priodasol fel p&#226;r, dylech ennill £{0} neu lai’r flwyddyn. Er mwyn bod yn gymwys, mae’n rhaid i’ch partner ennill rhwng £{1} a £{2} y flwyddyn.
 change.other.income.link	=	Er mwyn rhoi gwybod i ni am newid mewn incwm, cysylltwch &#226; CThEM
 change.other.sub.caption2	=	Profedigaeth
-change.other.bereavement.content	=	Os yw''ch partner yn marw, bydd eich Lwfans Priodasol yn newid.
+change.other.bereavement.content	=	Os yw’ch partner yn marw, bydd eich Lwfans Priodasol yn newid.
 change.other.bereavement.link	=	Er mwyn rhoi gwybod i ni am brofedigaeth, cysylltwch &#226; CThEM
 change.status.active	=	Gweithredol
 

--- a/test/controllers/ContentTest.scala
+++ b/test/controllers/ContentTest.scala
@@ -79,7 +79,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val form = document.getElementById("register-form")
       form shouldNot be(null)
       document.getElementById("form-error-heading").text() shouldBe "There is a problem"
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(last-name,name)").size() shouldBe 1
     }
 
@@ -96,7 +96,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val form = document.getElementById("register-form")
       form shouldNot be(null)
       document.getElementById("form-error-heading").text() shouldBe "There is a problem"
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
 
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(gender,last-name,name,nino)").size() shouldBe 1
     }
@@ -117,9 +117,9 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's first name."
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s first name."
       document.getElementById("form-error-heading").text() shouldBe "There is a problem"
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(name)").size() shouldBe 1
     }
 
@@ -137,8 +137,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's first name."
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s first name."
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
     }
 
     "display form error message (first name is blank)" in {
@@ -155,8 +155,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's first name."
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s first name."
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
     }
 
     "display form error message (first name contains more than 35 characters)" in {
@@ -174,7 +174,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use up to or no more than 35 letters."
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
     }
 
     "display form error message (first name contains numbers)" in {
@@ -192,7 +192,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use letters only."
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
     }
 
     "display form error message (first name contains letters and numbers)" in {
@@ -210,7 +210,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use letters only."
-      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner's first name"
+      document.getElementById("name-error").text() shouldBe "Confirm your spouse or civil partner’s first name"
     }
 
     "display form error message when recipient nino equals transferor nino" in {
@@ -227,8 +227,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelNino = form.select("label[for=nino]").first()
       labelNino.getElementsByClass("error-message").first() shouldNot be(null)
-      labelNino.getElementsByClass("error-message").first().text() shouldBe "You can't enter your own details."
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      labelNino.getElementsByClass("error-message").first().text() shouldBe "You can’t enter your own details."
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
     }
 
     "display form error message when recipient nino equals transferor nino (including mixed case and spaces)" in {
@@ -245,8 +245,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelNino = form.select("label[for=nino]").first()
       labelNino.getElementsByClass("error-message").first() shouldNot be(null)
-      labelNino.getElementsByClass("error-message").first().text() shouldBe "You can't enter your own details."
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      labelNino.getElementsByClass("error-message").first().text() shouldBe "You can’t enter your own details."
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
     }
   }
 
@@ -265,8 +265,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's last name."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s last name."
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(last-name)").size() shouldBe 1
     }
 
@@ -284,8 +284,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's last name."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s last name."
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
     }
 
     "display form error message (last name is blank)" in {
@@ -302,8 +302,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's last name."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s last name."
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
     }
 
     "display form error message (last name contains more than 35 characters)" in {
@@ -321,7 +321,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use up to or no more than 35 letters."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
     }
 
     "display form error message (last name contains numbers)" in {
@@ -339,7 +339,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use letters only."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
     }
 
     "display form error message (last name contains letters and numbers)" in {
@@ -357,7 +357,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=last-name]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Use letters only."
-      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner's last name"
+      document.getElementById("last-name-error").text() shouldBe "Confirm your spouse or civil partner’s last name"
     }
   }
 
@@ -376,8 +376,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("fieldset[id=gender]").first()
       labelName.getElementsByClass("error-notification").first() shouldNot be(null)
-      labelName.getElementsByClass("error-notification").first().text() shouldBe "Tell us your spouse or civil partner's gender."
-      document.getElementById("gender-error").text() shouldBe "Confirm your spouse or civil partner's gender"
+      labelName.getElementsByClass("error-notification").first().text() shouldBe "Tell us your spouse or civil partner’s gender."
+      document.getElementById("gender-error").text() shouldBe "Confirm your spouse or civil partner’s gender"
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(gender)").size() shouldBe 1
     }
 
@@ -395,8 +395,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("fieldset[id=gender]").first()
       labelName.getElementsByClass("error-notification").first() shouldNot be(null)
-      labelName.getElementsByClass("error-notification").first().text() shouldBe "Tell us your spouse or civil partner's gender."
-      document.getElementById("gender-error").text() shouldBe "Confirm your spouse or civil partner's gender"
+      labelName.getElementsByClass("error-notification").first().text() shouldBe "Tell us your spouse or civil partner’s gender."
+      document.getElementById("gender-error").text() shouldBe "Confirm your spouse or civil partner’s gender"
     }
   }
 
@@ -415,8 +415,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=nino]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's National Insurance number."
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s National Insurance number."
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
       document.getElementsByAttributeValue("data-journey", "marriage-allowance:stage:transfer-erroneous(nino)").size() shouldBe 1
     }
 
@@ -434,8 +434,8 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       form shouldNot be(null)
       val labelName = form.select("label[for=nino]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's National Insurance number."
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s National Insurance number."
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
     }
 
     "display form error message (NINO is invalid)" in {
@@ -453,7 +453,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       val labelName = form.select("label[for=nino]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
       labelName.getElementsByClass("error-message").first().text() shouldBe "Check their National Insurance number and enter it correctly."
-      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner's National Insurance number"
+      document.getElementById("nino-error").text() shouldBe "Confirm your spouse or civil partner’s National Insurance number"
     }
   }
 
@@ -483,7 +483,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
       back.attr("href") shouldBe marriageAllowanceUrl("/transfer-allowance")
     }
 
-    "display form error message (date of marriage is after today's date)" in {
+    "display form error message (date of marriage is after today’s date)" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val trRecipientData = Some(CacheData(transferor = Some(trrec), recipient = None, notification = None))
       val testComponent = makeTestComponent(
@@ -786,7 +786,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
 
       val button = document.getElementById("get-started")
       button shouldNot be(null)
-      button.text shouldBe "Start now to see if you're eligible for Marriage Allowance"
+      button.text shouldBe "Start now to see if you’re eligible for Marriage Allowance"
     }
 
   }
@@ -906,11 +906,11 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
 
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
-      document.title() shouldBe "Your partner's income - Marriage Allowance eligibility - GOV.UK"
+      document.title() shouldBe "Your partner’s income - Marriage Allowance eligibility - GOV.UK"
 
       document.getElementsByClass("bold-small").text shouldBe "Does this apply to your partner?"
       document.getElementsByClass("information").text shouldBe "To be eligible for Marriage Allowance, your partner must earn between £11,501 and £45,000 a year. This is their income figure before any tax is deducted."
-      document.getElementsByClass("heading-xlarge").text shouldBe "Check your eligibility Your partner's income"
+      document.getElementsByClass("heading-xlarge").text shouldBe "Check your eligibility Your partner’s income"
     }
   }
 
@@ -953,7 +953,7 @@ class ContentTest extends UnitSpec with TestUtility with OneAppPerSuite {
 
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
-      document.title() shouldBe "Your partner's income - Marriage Allowance eligibility - GOV.UK"
+      document.title() shouldBe "Your partner’s income - Marriage Allowance eligibility - GOV.UK"
       document.getElementsByClass("bold-small").text shouldBe "Does this apply to your partner?"
       document.getElementsByClass("Information").text shouldBe "To be eligible for Marriage Allowance, your partner must earn between £11,501 and £45,000 a year. This is their income figure before any tax is deducted."
     }

--- a/test/controllers/EligibilityCalcControllerTest.scala
+++ b/test/controllers/EligibilityCalcControllerTest.scala
@@ -126,18 +126,18 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       document.getElementById("calculator-result").text() shouldBe "Based on the details you have provided you will not benefit from making the transfer."
     }
 
-    "show 'recipient is not eligible' if transferor income=9540  and recipient income<11501" in {
+    "show ’recipient is not eligible’ if transferor income=9540  and recipient income<11501" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "9540", "recipient-income" -> "11000")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
-    "show 'recipient is not eligible' if transferor income=9540  and recipient income>45000" in {
+    "show ’recipient is not eligible’ if transferor income=9540  and recipient income>45000" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "9540", "recipient-income" -> "46001")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
   }
 
@@ -300,8 +300,8 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       val form = document.getElementById("calculator")
       form.getElementsByClass("error-message").first() shouldNot be(null)
       val yourIncome = form.select("label[for=recipient-income]").first()
-      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner's annual income"
-      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's annual income."
+      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner’s annual income"
+      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s annual income."
     }
 
     "be displayed if recipient income is not provided (Empty)" in {
@@ -311,8 +311,8 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       val form = document.getElementById("calculator")
       form.getElementsByClass("error-message").first() shouldNot be(null)
       val yourIncome = form.select("label[for=recipient-income]").first()
-      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner's annual income"
-      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's annual income."
+      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner’s annual income"
+      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s annual income."
     }
 
     "be displayed if recipient income is not provided (Blank)" in {
@@ -322,8 +322,8 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       val form = document.getElementById("calculator")
       form.getElementsByClass("error-message").first() shouldNot be(null)
       val yourIncome = form.select("label[for=recipient-income]").first()
-      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner's annual income"
-      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's annual income."
+      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner’s annual income"
+      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s annual income."
     }
 
     "be displayed if recipient income contains letters" in {
@@ -360,28 +360,28 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "0", "recipient-income" -> "0")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
     "be displayed if transferor income=9000 (< 9540) and recipient income=5000 (< 10600)" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "9000", "recipient-income" -> "5000")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "Check the numbers you've entered. Please enter the lower earner's income followed by the higher earner's income."
+      document.getElementById("calculator-result").text() shouldBe "Check the numbers you’ve entered. Please enter the lower earner’s income followed by the higher earner’s income."
     }
 
     "be displayed if transferor income=9000 (< 9540) and recipient income=46000 (> 45000)" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "9000", "recipient-income" -> "46000")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
     "be displayed if transferor income=10000 (9540-11000) and recipient exceeds limit" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "10000", "recipient-income" -> "46000")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
     "be displayed if transferor income is below limit and recipient income=20000" in {
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "11501", "recipient-income" -> "20000")
@@ -393,7 +393,7 @@ class EligibilityCalcControllerTest extends UnitSpec with TestUtility with OneAp
       val request = FakeRequest().withFormUrlEncodedBody("transferor-income" -> "43001", "recipient-income" -> "20000")
       val result = makeEligibilityController().calculatorAction()(request)
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "Check the numbers you've entered. Please enter the lower earner's income followed by the higher earner's income."
+      document.getElementById("calculator-result").text() shouldBe "Check the numbers you’ve entered. Please enter the lower earner’s income followed by the higher earner’s income."
     }
   }
 }

--- a/test/controllers/ErrorsTest.scala
+++ b/test/controllers/ErrorsTest.scala
@@ -34,7 +34,7 @@ class ErrorsTest extends UnitSpec with TestUtility with OneAppPerSuite {
   implicit override lazy val app: Application = fakeApplication
 
   "Error handling in transfer page when submitting form" should {
-    "show 'Recipient details not found' page" in {
+    "show ’Recipient details not found’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
       val rcrec = UserRecord(cid = 123456, timestamp = "2015")
       val cacheRecipientFormData = Some(RecipientDetailsFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoTransferorNotFound)))
@@ -62,7 +62,7 @@ class ErrorsTest extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("error").text() shouldBe "We were unable to find a HMRC record of your spouse or civil partner."
     }
 
-    "show 'Technical Exception' page" in {
+    "show ’Technical Exception’ page" in {
       val loggedInUser = LoggedInUserInfo(999700101, "2015", None, TestConstants.GENERIC_CITIZEN_NAME)
       val relationshipRecord = RelationshipRecord(Role.RECIPIENT, "98765", "20130101", Some(""), Some("20140101"), "", "")
       val updateRelationshipCacheData = UpdateRelationshipCacheData(loggedInUserInfo = Some(loggedInUser),
@@ -75,7 +75,7 @@ class ErrorsTest extends UnitSpec with TestUtility with OneAppPerSuite {
 
       status(result) shouldBe INTERNAL_SERVER_ERROR
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("error").text() shouldBe "We're experiencing technical difficulties"
+      document.getElementById("error").text() shouldBe "We’re experiencing technical difficulties"
     }
 
     "send audit event if recipient can not be found" in {
@@ -144,7 +144,7 @@ class ErrorsTest extends UnitSpec with TestUtility with OneAppPerSuite {
       eventsShouldMatch(event, "TxFailed", detailsToCheck, tags)
     }
 
-    "show 'no tax years for transferor' page if transferor enters date of marriage as current tax year" in {
+    "show ’no tax years for transferor’ page if transferor enters date of marriage as current tax year" in {
 
       val cachedRecipientData = Some(RecipientDetailsFormInput("foo", "bar", Gender("M"), Nino(Ninos.ninoWithLOA1)))
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
@@ -172,12 +172,12 @@ class ErrorsTest extends UnitSpec with TestUtility with OneAppPerSuite {
       status(result) shouldBe INTERNAL_SERVER_ERROR
 
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("description").text() shouldBe "Based on the date of marriage or civil partnership you've provided, you're not eligible for Marriage Allowance."
+      document.getElementById("description").text() shouldBe "Based on the date of marriage or civil partnership you’ve provided, you’re not eligible for Marriage Allowance."
     }
   }
 
   "Error handling in confirm page" should {
-    "show 'Cannot Create Relationship' page" in {
+    "show ’Cannot Create Relationship’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
       val rcrec = UserRecord(cid = 123456, timestamp = "2015")
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoTransferorNotFound), dateOfMarriage = new LocalDate(2015, 1, 1))

--- a/test/controllers/MarriageAllowanceControllerTest.scala
+++ b/test/controllers/MarriageAllowanceControllerTest.scala
@@ -35,7 +35,7 @@ class MarriageAllowanceControllerTest extends UnitSpec with TestUtility with One
   implicit override lazy val app: Application = fakeApplication
 
   "Calling transfer Form page" should {
-    "display registration page if transferor exits and doesn't have existing relationship" in {
+    "display registration page if transferor exits and doesn’t have existing relationship" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val trRecipientData = Some(CacheData(transferor = Some(trrec), recipient = None, notification = None))
       val testComponent = makeTestComponent("user_happy_path", transferorRecipientData = trRecipientData)
@@ -248,7 +248,7 @@ class MarriageAllowanceControllerTest extends UnitSpec with TestUtility with One
 
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("message").text() shouldBe "You haven't selected any tax years to apply for"
+      document.getElementById("message").text() shouldBe "You haven’t selected any tax years to apply for"
     }
   }
 
@@ -401,7 +401,7 @@ class MarriageAllowanceControllerTest extends UnitSpec with TestUtility with One
 
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("message").text() shouldBe "You haven't selected any tax years to apply for"
+      document.getElementById("message").text() shouldBe "You haven’t selected any tax years to apply for"
     }
 
     "redirect if no year is selected (empty list)" in {
@@ -419,7 +419,7 @@ class MarriageAllowanceControllerTest extends UnitSpec with TestUtility with One
 
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("message").text() shouldBe "You haven't selected any tax years to apply for"
+      document.getElementById("message").text() shouldBe "You haven’t selected any tax years to apply for"
     }
 
     "retrieve correct keystore data for female recipient" in {
@@ -453,8 +453,8 @@ class MarriageAllowanceControllerTest extends UnitSpec with TestUtility with One
       document.getElementById("year-2014").text() shouldBe "Previous tax year: 6 April 2014 to 5 April 2015"
       document.getElementById("year-2015").text() shouldBe "Previous tax year: 6 April 2015 to 5 April 2016"
 
-      document.getElementById("outcome-2014").text() shouldBe "HMRC will check the details you've supplied before sending foo a cheque by post for up to £212."
-      document.getElementById("outcome-2015").text() shouldBe "HMRC will check the details you've supplied before sending foo a cheque by post for up to £212."
+      document.getElementById("outcome-2014").text() shouldBe "HMRC will check the details you’ve supplied before sending foo a cheque by post for up to £212."
+      document.getElementById("outcome-2015").text() shouldBe "HMRC will check the details you’ve supplied before sending foo a cheque by post for up to £212."
 
       document.getElementById("change-2014").attr("href") shouldBe "/marriage-allowance-application/eligible-years"
       document.getElementById("change-2015").attr("href") shouldBe "/marriage-allowance-application/eligible-years"

--- a/test/controllers/PtaEligibilityCalcControllerTest.scala
+++ b/test/controllers/PtaEligibilityCalcControllerTest.scala
@@ -134,16 +134,16 @@ class PtaEligibilityCalcControllerTest extends UnitSpec with TestUtility with On
     }
 
 
-    "show 'recipient is not eligible' if transferor income=9540  and recipient income<11001" in {
+    "show ’recipient is not eligible’ if transferor income=9540  and recipient income<11001" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "9540", "recipient-income" -> "11000"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
-    "show 'recipient is not eligible' if transferor income=9540  and recipient income>45000" in {
+    "show ’recipient is not eligible’ if transferor income=9540  and recipient income>45000" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "9540", "recipient-income" -> "46001"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
   }
@@ -279,8 +279,8 @@ class PtaEligibilityCalcControllerTest extends UnitSpec with TestUtility with On
       val form = document.getElementById("calculator")
       form.getElementsByClass("error-message").first() shouldNot be(null)
       val yourIncome = form.select("label[for=recipient-income]").first()
-      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner's annual income"
-      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's annual income."
+      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner’s annual income"
+      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s annual income."
     }
 
     "be displayed if recipient income is not provided (Empty)" in {
@@ -289,8 +289,8 @@ class PtaEligibilityCalcControllerTest extends UnitSpec with TestUtility with On
       val form = document.getElementById("calculator")
       form.getElementsByClass("error-message").first() shouldNot be(null)
       val yourIncome = form.select("label[for=recipient-income]").first()
-      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner's annual income"
-      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner's annual income."
+      document.getElementById("recipient-income-error").text shouldBe "Confirm your spouse or civil partner’s annual income"
+      yourIncome.getElementsByClass("error-message").first().text() shouldBe "Tell us your spouse or civil partner’s annual income."
     }
 
     "be displayed if recipient income contains letters" in {
@@ -323,25 +323,25 @@ class PtaEligibilityCalcControllerTest extends UnitSpec with TestUtility with On
     "be displayed if transferor income=0 (< 9540) and recipient income=0 (10600-11660)" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "0", "recipient-income" -> "0"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
     "be displayed if transferor income=9000 (< 9540) and recipient income=5000 (< 11000)" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "9000", "recipient-income" -> "5000"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "Check the numbers you've entered. Please enter the lower earner's income followed by the higher earner's income."
+      document.getElementById("calculator-result").text() shouldBe "Check the numbers you’ve entered. Please enter the lower earner’s income followed by the higher earner’s income."
     }
 
     "be displayed if transferor income=9000 (< 9540) and recipient income=47000 (> 45000)" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "9000", "recipient-income" -> "46000"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
 
     "be displayed if transferor income=10000 (9540-10600) and recipient income=46000 (> 45000)" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "10000", "recipient-income" -> "46000"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner's annual income must be between £11,501 and £45,000."
+      document.getElementById("calculator-result").text() shouldBe "You are not eligible for Marriage Allowance. Your spouse or civil partner’s annual income must be between £11,501 and £45,000."
     }
     "be displayed if transferor income=11001 (>11000) and recipient income=20000" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "11501", "recipient-income" -> "20000"))
@@ -351,7 +351,7 @@ class PtaEligibilityCalcControllerTest extends UnitSpec with TestUtility with On
     "be displayed if transferor income=43001 (>42385) and recipient income=20000" in {
       val result = calculatorRequestAction(Map("transferor-income" -> "43001", "recipient-income" -> "20000"))
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("calculator-result").text() shouldBe "Check the numbers you've entered. Please enter the lower earner's income followed by the higher earner's income."
+      document.getElementById("calculator-result").text() shouldBe "Check the numbers you’ve entered. Please enter the lower earner’s income followed by the higher earner’s income."
     }
   }
 }

--- a/test/controllers/RoutesTest.scala
+++ b/test/controllers/RoutesTest.scala
@@ -122,7 +122,7 @@ class RoutesTest extends UnitSpec with TestUtility with OneAppPerSuite {
   }
 
   "Hitting calculator page" should {
-    "have a 'previous' and 'next' links to gov.ukpage" in {
+    "have a ’previous’ and ’next’ links to gov.ukpage" in {
       val request = FakeRequest()
       val controllerToTest = makeEligibilityController()
       val result = controllerToTest.calculator()(request)
@@ -585,7 +585,7 @@ class RoutesTest extends UnitSpec with TestUtility with OneAppPerSuite {
       redirectLocation(result) shouldBe Some("bar")
     }
 
-    "go to finish in 'nyn' scenario" in {
+    "go to finish in ’nyn’ scenario" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withFormUrlEncodedBody("marriage-criteria" -> "false", "recipient-income-criteria" -> "true", "transferor-income-criteria" -> "false")
       val controllerToTest = testComponent.controller
@@ -791,7 +791,7 @@ class RoutesTest extends UnitSpec with TestUtility with OneAppPerSuite {
       status(result) shouldBe BAD_REQUEST
 
       val document = Jsoup.parse(contentAsString(result))
-      document.title() shouldBe "Your partner's income - Marriage Allowance eligibility - GOV.UK"
+      document.title() shouldBe "Your partner’s income - Marriage Allowance eligibility - GOV.UK"
       document.getElementById("form-error-heading").text() shouldBe TestConstants.ERROR_HEADING
       document.getElementById("partners-income-error").text() shouldBe "Confirm if your spouse or civil partner has an annual income of between £11,501 and £45,000"
       val back = document.getElementsByClass("link-back")
@@ -907,10 +907,10 @@ class RoutesTest extends UnitSpec with TestUtility with OneAppPerSuite {
       status(result) shouldBe BAD_REQUEST
 
       val document = Jsoup.parse(contentAsString(result))
-      document.title() shouldBe "Your partner's income - Marriage Allowance eligibility - GOV.UK"
+      document.title() shouldBe "Your partner’s income - Marriage Allowance eligibility - GOV.UK"
       document.getElementById("form-error-heading").text() shouldBe TestConstants.ERROR_HEADING
 
-      document.getElementsByClass("partners-inc-error").text shouldBe "You're not eligible for Marriage Allowance in this tax year because your partner's income is too high or too low. You can still continue to check your eligibility for previous years."
+      document.getElementsByClass("partners-inc-error").text shouldBe "You’re not eligible for Marriage Allowance in this tax year because your partner’s income is too high or too low. You can still continue to check your eligibility for previous years."
 
       val back = document.getElementsByClass("link-back")
       back shouldNot be(null)

--- a/test/controllers/Signout.scala
+++ b/test/controllers/Signout.scala
@@ -35,7 +35,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
 
   "PTA Sign out and status" should {
 
-    "be on 'How It Works' page for returning user" in {
+    "be on ’How It Works’ page for returning user" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_returning")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller
@@ -47,7 +47,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, you last signed in 9:00am, Friday 13 November 2015"
     }
 
-    "be on 'How It Works' page" in {
+    "be on ’How It Works’ page" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller
@@ -59,7 +59,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "be on 'Calculator' page" in {
+    "be on ’Calculator’ page" in {
       val testComponent = makePtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller
@@ -71,7 +71,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "be on 'Eligibility Check' page" in {
+    "be on ’Eligibility Check’ page" in {
       val testComponent = makePtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller
@@ -83,7 +83,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "be on 'Transfer' page" in {
+    "be on ’Transfer’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val trRecipientData = Some(CacheData(transferor = Some(trrec), recipient = None, notification = None))
       val testComponent = makeTestComponent("user_happy_path", transferorRecipientData = trRecipientData)
@@ -97,7 +97,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "be on 'Confirm Email' page" in {
+    "be on ’Confirm Email’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015", name = None)
       val cachedRecipientData = Some(RegistrationFormInput("foo", "bar", Gender("F"), Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1)))
@@ -116,7 +116,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
 
     }
 
-    "be on 'Confirm' page" in {
+    "be on ’Confirm’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015", name = None)
       val cachedRecipientData = Some(RegistrationFormInput("foo", "bar", Gender("F"), Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1)))
@@ -140,7 +140,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "be on 'Finished' page" in {
+    "be on ’Finished’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015")
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1))
@@ -158,7 +158,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "show sign-out on 'Recipient details not found' page" in {
+    "show sign-out on ’Recipient details not found’ page" in {
       val loggedInUser = LoggedInUserInfo(999700101, "2015", None, TestConstants.GENERIC_CITIZEN_NAME)
       val relationshipRecord = RelationshipRecord(Role.RECIPIENT, "", "", Some(""), Some(""), "", "")
       val updateRelationshipCacheData = UpdateRelationshipCacheData(loggedInUserInfo = Some(loggedInUser),
@@ -176,7 +176,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "show sign-out on 'Technical Exceptions' page" in {
+    "show sign-out on ’Technical Exceptions’ page" in {
 
       val loggedInUser = LoggedInUserInfo(999700101, "2015", None, TestConstants.GENERIC_CITIZEN_NAME)
       val relationshipRecord = RelationshipRecord(Role.RECIPIENT, "", "", Some(""), Some(""), "", "")
@@ -195,7 +195,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
-    "show sign-out on 'Cannot Create Relationship' page" in {
+    "show sign-out on ’Cannot Create Relationship’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
       val rcrec = UserRecord(cid = Cids.cid5, timestamp = "2015")
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoTransferorNotFound), dateOfMarriage = new LocalDate(2015, 1, 1))
@@ -213,7 +213,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "show 'Technical Exception' page" in {
+    "show ’Technical Exception’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = 999999, timestamp = "2015", name = None)
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoError), dateOfMarriage = new LocalDate(2015, 1, 1))
@@ -227,12 +227,12 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
 
       status(result) shouldBe INTERNAL_SERVER_ERROR
       val document = Jsoup.parse(contentAsString(result))
-      document.getElementById("error").text() shouldBe "We're experiencing technical difficulties"
+      document.getElementById("error").text() shouldBe "We’re experiencing technical difficulties"
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "show sign-out on 'Technical Exception' pages" in {
+    "show sign-out on ’Technical Exception’ pages" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = 999999, timestamp = "2015", name = None)
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoError), dateOfMarriage = new LocalDate(2015, 1, 1))
@@ -253,7 +253,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
   }
 
   "GDS Sign out" should {
-    "be on 'How It Works' page" in {
+    "be on ’How It Works’ page" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "GDS"))
       val controllerToTest = testComponent.controller
@@ -264,7 +264,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Calculator' page" in {
+    "be on ’Calculator’ page" in {
       val testComponent = makePtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "GDS"))
       val controllerToTest = testComponent.controller
@@ -275,7 +275,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Eligibility Check' page" in {
+    "be on ’Eligibility Check’ page" in {
       val testComponent = makePtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "GDS"))
       val controllerToTest = testComponent.controller
@@ -286,7 +286,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Transfer' page" in {
+    "be on ’Transfer’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val trRecipientData = Some(CacheData(transferor = Some(trrec), recipient = None, notification = None))
       val testComponent = makeTestComponent("user_happy_path", transferorRecipientData = trRecipientData)
@@ -299,7 +299,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Confirm Email' page" in {
+    "be on ’Confirm Email’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015", name = None)
       val cachedRecipientData = Some(RegistrationFormInput("foo", "bar", Gender("F"), Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1)))
@@ -316,7 +316,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Confirm' page" in {
+    "be on ’Confirm’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015", name = TestConstants.GENERIC_CITIZEN_NAME)
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015", name = None)
       val cachedRecipientData = Some(RegistrationFormInput("foo", "bar", Gender("F"), Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1)))
@@ -339,7 +339,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "be on 'Finished' page" in {
+    "be on ’Finished’ page" in {
       val trrec = UserRecord(cid = Cids.cid1, timestamp = "2015")
       val rcrec = UserRecord(cid = Cids.cid2, timestamp = "2015")
       val rcdata = RegistrationFormInput(name = "foo", lastName = "bar", gender = Gender("M"), nino = Nino(Ninos.ninoWithLOA1), dateOfMarriage = new LocalDate(2015, 1, 1))
@@ -359,7 +359,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
 
   "PTA Sign out and status for multi year" should {
 
-    "be on 'How It Works' page for returning user" in {
+    "be on ’How It Works’ page for returning user" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_returning")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller
@@ -371,7 +371,7 @@ class Signout extends UnitSpec with TestUtility with OneAppPerSuite {
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, you last signed in 9:00am, Friday 13 November 2015"
     }
 
-    "be on 'How It Works' page" in {
+    "be on ’How It Works’ page" in {
       val testComponent = makeMultiYearPtaEligibilityTestComponent("user_happy_path")
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
       val controllerToTest = testComponent.controller

--- a/test/controllers/UpdateRelationshipContentTest.scala
+++ b/test/controllers/UpdateRelationshipContentTest.scala
@@ -144,7 +144,7 @@ class UpdateRelationshipContentTest extends UnitSpec with UpdateRelationshipTest
       document.getElementById("line1-remove") shouldNot be(null)
     }
 
-    "don't display apply for previous years button when previous years are available" in {
+    "don’t display apply for previous years button when previous years are available" in {
 
       val testComponent = makeUpdateRelationshipTestComponent("coc_historic_rejectable_relationship")
       val controllerToTest = testComponent.controller
@@ -158,7 +158,7 @@ class UpdateRelationshipContentTest extends UnitSpec with UpdateRelationshipTest
       prevYearsButton shouldNot be(null)
     }
 
-    "display 'apply for previous years' button if historic year is available" in {
+    "display ’apply for previous years’ button if historic year is available" in {
       val testComponent = makeUpdateRelationshipTestComponent("coc_gap_in_years")
       val controllerToTest = testComponent.controller
       val request = testComponent.request
@@ -237,7 +237,7 @@ class UpdateRelationshipContentTest extends UnitSpec with UpdateRelationshipTest
       val contentAsStringFromResult = contentAsString(result)
       val document = Jsoup.parse(contentAsString(result))
       val historicActiveMessage = document.getElementById("historicActiveMessage").text()
-      historicActiveMessage should be("You'll stop receiving Marriage Allowance from your spouse or civil partner at end of the tax year (5 April 2017).")
+      historicActiveMessage should be("You’ll stop receiving Marriage Allowance from your spouse or civil partner at end of the tax year (5 April 2017).")
 
       val historicRecord = document.getElementById("historicRecords")
       historicRecord shouldNot be(null)
@@ -342,7 +342,7 @@ class UpdateRelationshipContentTest extends UnitSpec with UpdateRelationshipTest
       cancelContent shouldNot be(null)
 
       cancelHeading.toString contains ("Cancelling Marriage Allowance") should be(true)
-      cancelContent.text() shouldBe "We'll cancel your Marriage Allowance, but it will remain in place until 5 April 2017, the end of the current tax year."
+      cancelContent.text() shouldBe "We’ll cancel your Marriage Allowance, but it will remain in place until 5 April 2017, the end of the current tax year."
 
     }
 
@@ -363,7 +363,7 @@ class UpdateRelationshipContentTest extends UnitSpec with UpdateRelationshipTest
       cancelContent shouldNot be(null)
 
       cancelHeading.toString contains ("Cancelling Marriage Allowance") should be(true)
-      cancelContent.text() shouldBe "We'll cancel your Marriage Allowance, but it will remain in place until 5 April 2017, the end of the current tax year."
+      cancelContent.text() shouldBe "We’ll cancel your Marriage Allowance, but it will remain in place until 5 April 2017, the end of the current tax year."
 
     }
 

--- a/test/controllers/UpdateRelationshipControllerTest.scala
+++ b/test/controllers/UpdateRelationshipControllerTest.scala
@@ -182,7 +182,7 @@ class UpdateRelationshipControllerTest extends UnitSpec with UpdateRelationshipT
 
       val document = Jsoup.parse(contentAsString(result))
       document.getElementById("confirm-page").text() shouldBe "Confirm removal of a previous Marriage Allowance claim"
-      document.getElementById("confirm-note").text() shouldBe "You've asked us to remove your Marriage Allowance from tax year 2010 to 2015. This means:"
+      document.getElementById("confirm-note").text() shouldBe "You’ve asked us to remove your Marriage Allowance from tax year 2010 to 2015. This means:"
     }
 
     "have update relationship action details in cache " in {
@@ -320,7 +320,7 @@ class UpdateRelationshipControllerTest extends UnitSpec with UpdateRelationshipT
 
   "Calling history page" should {
 
-    "show sign-out on 'History' page with PTA journey" in {
+    "show sign-out on ’History’ page with PTA journey" in {
       val testComponent = makeUpdateRelationshipTestComponent("coc_active_historic_relationship")
       val controllerToTest = testComponent.controller
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
@@ -332,7 +332,7 @@ class UpdateRelationshipControllerTest extends UnitSpec with UpdateRelationshipT
       document.getElementById("user-status").getElementsByTag("p").text() shouldBe "Test_name, this is the first time you have logged in"
     }
 
-    "show sign-out on 'History' page with GDS journey" in {
+    "show sign-out on ’History’ page with GDS journey" in {
       val testComponent = makeUpdateRelationshipTestComponent("coc_active_historic_relationship")
       val controllerToTest = testComponent.controller
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "GDS"))
@@ -343,7 +343,7 @@ class UpdateRelationshipControllerTest extends UnitSpec with UpdateRelationshipT
       document.getElementById("sign-out").attr("href") shouldBe "/marriage-allowance-application/logout"
     }
 
-    "show beta feedback on 'History' page" in {
+    "show beta feedback on ’History’ page" in {
       val testComponent = makeUpdateRelationshipTestComponent("coc_active_historic_relationship")
       val controllerToTest = testComponent.controller
       val request = testComponent.request.withCookies(Cookie("TAMC_JOURNEY", "PTA"))
@@ -355,7 +355,7 @@ class UpdateRelationshipControllerTest extends UnitSpec with UpdateRelationshipT
       feedback.attr("href") shouldBe "http://localhost:9250/contact/beta-feedback-unauthenticated?service=TAMC"
     }
 
-    "show sign-out on 'History' page along with message" in {
+    "show sign-out on ’History’ page along with message" in {
       val testComponent = makeUpdateRelationshipTestComponent("coc_active_historic_relationship")
       val controllerToTest = testComponent.controller
       val request = testComponent.request

--- a/test/controllers/UpdateRelationshipRoutesTest.scala
+++ b/test/controllers/UpdateRelationshipRoutesTest.scala
@@ -82,7 +82,7 @@ class UpdateRelationshipRoutesTest extends UnitSpec with UpdateRelationshipTestU
       status(result) shouldBe OK
       val document = Jsoup.parse(contentAsString(result))
       val heading = document.getElementsByClass("heading-xlarge").text()
-      heading should be("We're sorry for your loss")
+      heading should be("We’re sorry for your loss")
 
     }
   }


### PR DESCRIPTION
DDCNLS-1069: Changed MA content for new tax year "You can backdate your claim to include any tax year since 5 April 2015 that you were eligible for Marriage Allowance."