### PR TITLE
DDCNLS-5962 : Welsh toggle causes page not found

### DIFF
--- a/app/controllers/TransferController.scala
+++ b/app/controllers/TransferController.scala
@@ -32,10 +32,11 @@ import models.auth.UserRequest
 import org.apache.commons.lang3.exception.ExceptionUtils
 import play.Logger
 import play.api.data.FormError
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Lang, MessagesApi}
 import play.api.mvc._
 import services.{CachingService, TimeService, TransferService}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.language.LanguageUtils
 import uk.gov.hmrc.play.partials.FormPartialRetriever
 import uk.gov.hmrc.renderer.TemplateRenderer
 
@@ -71,6 +72,18 @@ class TransferController @Inject()(
   def dateOfMarriage: Action[AnyContent] = authenticate {
     implicit request =>
       Ok(views.html.date_of_marriage(marriageForm = dateOfMarriageForm(today = timeService.getCurrentDate)))
+  }
+
+  def dateOfMarriageWithCy: Action[AnyContent] = authenticate {
+    implicit request =>
+      Redirect(controllers.routes.TransferController.dateOfMarriage()).withLang(Lang("cy"))
+        .flashing(LanguageUtils.FlashWithSwitchIndicator)
+  }
+
+  def dateOfMarriageWithEn: Action[AnyContent] = authenticate {
+    implicit request =>
+      Redirect(controllers.routes.TransferController.dateOfMarriage()).withLang(Lang("en"))
+        .flashing(LanguageUtils.FlashWithSwitchIndicator)
   }
 
   def dateOfMarriageAction: Action[AnyContent] = authenticate.async {

--- a/app/controllers/UpdateRelationshipController.scala
+++ b/app/controllers/UpdateRelationshipController.scala
@@ -26,10 +26,11 @@ import models._
 import models.auth.UserRequest
 import org.joda.time.LocalDate
 import play.Logger
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Lang, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Result}
 import services.{CachingService, TimeService, TransferService, UpdateRelationshipService}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.language.LanguageUtils
 import uk.gov.hmrc.play.partials.FormPartialRetriever
 import uk.gov.hmrc.renderer.TemplateRenderer
 import uk.gov.hmrc.time
@@ -70,6 +71,18 @@ class UpdateRelationshipController @Inject()(
           }
         }
       } recover handleError
+  }
+
+  def historyWithCy: Action[AnyContent] = authenticate {
+    implicit request =>
+      Redirect(controllers.routes.UpdateRelationshipController.history()).withLang(Lang("cy"))
+        .flashing(LanguageUtils.FlashWithSwitchIndicator)
+  }
+
+  def historyWithEn: Action[AnyContent] = authenticate {
+    implicit request =>
+      Redirect(controllers.routes.UpdateRelationshipController.history()).withLang(Lang("en"))
+        .flashing(LanguageUtils.FlashWithSwitchIndicator)
   }
 
   def makeChange(): Action[AnyContent] = authenticate {
@@ -313,6 +326,4 @@ class UpdateRelationshipController @Inject()(
           case _ => handle(Logger.error, InternalServerError(views.html.errors.try_later()))
         }
     }
-
-
 }

--- a/app/views/coc/divorce.scala.html
+++ b/app/views/coc/divorce.scala.html
@@ -33,6 +33,11 @@
 
 @templates.tamc_main(
     title = Messages("title.pattern", Messages("title.make-a-change")),
+    langSelectorOverride = Some(
+        Map("enUrl" -> controllers.routes.UpdateRelationshipController.historyWithEn(),
+            "cyUrl" -> controllers.routes.UpdateRelationshipController.historyWithCy()
+        )
+    ),
     mainConfig = views.helpers.MainConfig()) {
 
     <a href="@controllers.routes.UpdateRelationshipController.history" class="link-back">@Html(Messages("generic.back"))</a>

--- a/app/views/coc/divorce_select_year.scala.html
+++ b/app/views/coc/divorce_select_year.scala.html
@@ -24,8 +24,13 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
 formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever)
 
 @templates.tamc_main(
-title = Messages("title.pattern", Messages("title.divorce")),
-mainConfig = views.helpers.MainConfig()) {
+    title = Messages("title.pattern", Messages("title.divorce")),
+    langSelectorOverride = Some(
+        Map("enUrl" -> controllers.routes.UpdateRelationshipController.historyWithEn(),
+            "cyUrl" -> controllers.routes.UpdateRelationshipController.historyWithCy()
+        )
+    ),
+    mainConfig = views.helpers.MainConfig()) {
 
 <a href="@controllers.routes.UpdateRelationshipController.history" class="link-back">@Html(Messages("generic.back"))</a>
 

--- a/app/views/coc/reason_for_change.scala.html
+++ b/app/views/coc/reason_for_change.scala.html
@@ -24,8 +24,13 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
 formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever)
 
 @templates.tamc_main(
-title = Messages("title.pattern", Messages("title.make-a-change")),
-mainConfig = views.helpers.MainConfig()) {
+    title = Messages("title.pattern", Messages("title.make-a-change")),
+    langSelectorOverride = Some(
+        Map("enUrl" -> controllers.routes.UpdateRelationshipController.historyWithEn(),
+            "cyUrl" -> controllers.routes.UpdateRelationshipController.historyWithCy()
+        )
+    ),
+    mainConfig = views.helpers.MainConfig()) {
 
 <a href="@controllers.routes.UpdateRelationshipController.history" class="link-back">@Html(Messages("generic.back"))</a>
 

--- a/app/views/multiyear/transfer/previous_years.scala.html
+++ b/app/views/multiyear/transfer/previous_years.scala.html
@@ -33,7 +33,12 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
 formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever)
 
 @templates.tamc_main(
-title = Messages("title.application.pattern", Messages("title.extra-years"))){
+title = Messages("title.application.pattern", Messages("title.extra-years")),
+langSelectorOverride = Some(
+ Map("enUrl" -> controllers.routes.TransferController.dateOfMarriageWithEn(),
+     "cyUrl" -> controllers.routes.TransferController.dateOfMarriageWithCy()
+ )
+)){
 
 @if(currentYearAvailable) {
     <a href="@controllers.routes.TransferController.eligibleYears" class="link-back">@Html(Messages("generic.back"))</a>

--- a/app/views/multiyear/transfer/single_year_select.scala.html
+++ b/app/views/multiyear/transfer/single_year_select.scala.html
@@ -34,8 +34,12 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
 formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever)
 
 @templates.tamc_main(
-title = Messages("title.application.pattern", Messages("title.extra-years"))
-) {
+title = Messages("title.application.pattern", Messages("title.extra-years")),
+langSelectorOverride = Some(
+    Map("enUrl" -> controllers.routes.TransferController.dateOfMarriageWithEn(),
+        "cyUrl" -> controllers.routes.TransferController.dateOfMarriageWithCy()
+    )
+)) {
 
 <a href="@controllers.routes.TransferController.eligibleYearsAction"
    class="link-back">@Html(Messages("generic.back"))</a>

--- a/app/views/templates/tamc_main.scala.html
+++ b/app/views/templates/tamc_main.scala.html
@@ -27,83 +27,84 @@
 @import uk.gov.hmrc.play.views.helpers.AttorneyRegime.standAlone
 
 @(title: String,
-pageName:Option[String] = None,
-sidebarLinks: Option[Html] = None,
-sidebarClass: Option[String] = None,
-mainConfig: views.helpers.MainConfig = views.helpers.MainConfig(),
-appConfig: config.ApplicationConfig = config.ApplicationConfig,
-supportLinkEnabled: Boolean = true,
-langSwitch: Option[play.twirl.api.Html] = None,
-scriptElem: Option[Html] = None)(mainContent: Html)(implicit messages: Messages,
-request: UserRequest[_],
-gaDimensions: Option[Map[String, String]] = None,
-templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
-formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever
+ pageName:Option[String] = None,
+ sidebarLinks: Option[Html] = None,
+ sidebarClass: Option[String] = None,
+ mainConfig: views.helpers.MainConfig = views.helpers.MainConfig(),
+ appConfig: config.ApplicationConfig = config.ApplicationConfig,
+ supportLinkEnabled: Boolean = true,
+ langSwitch: Option[play.twirl.api.Html] = None,
+ scriptElem: Option[Html] = None,
+ langSelectorOverride: Option[Map[String, Call]] = None)(mainContent: Html)(implicit messages: Messages,
+ request: UserRequest[_],
+ gaDimensions: Option[Map[String, String]] = None,
+ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer,
+ formPartialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever
 )
+
+@langSelectorMap = @{
+ langSelectorOverride.getOrElse(
+  Map("enUrl" -> controllers.routes.LanguageController.enGb(),
+      "cyUrl" -> controllers.routes.LanguageController.cyGb()
+  )
+ )
+}
 
 
 @scriptElement = {
 
-<script type="text/javascript">
-            ga('require', 'linker');
-            if(document.referrer === "https://www.gov.uk/marriage-allowance"){
-                ga('set', 'referrer', '');
-            }
-            ga('require', 'displayfeatures');
+ <script type="text/javascript">
+    ga('require', 'linker');
+    if(document.referrer === "https://www.gov.uk/marriage-allowance"){
+        ga('set', 'referrer', '');
+    }
+    ga('require', 'displayfeatures');
+ </script>
 
-</script>
+ <script type="text/javascript">
+     function initCobrowse() {
+         if (typeof(eGain) != 'undefined' && eGain.cobrowse) {
+             eGain.cobrowse.startCobrowse();
+         }
+         else {
+             console.warn('eGain is not initialized')
+         }
+     }
+ </script>
 
-<script type="text/javascript">
-                        function initCobrowse() {
-                            if (typeof(eGain) != 'undefined' && eGain.cobrowse) {
-                                eGain.cobrowse.startCobrowse();
-                            }
-                            else {
-                                console.warn('eGain is not initialized')
-                            }
-                        }
+ <script type="text/javascript">
+   $.timeoutDialog({
+    timeout: 900,
+    countdown:120,
+    keep_alive_url: '/keep-alive',
+    logout_url: '/marriage-allowance-application/logout'
+   });
+ </script>
 
-</script>
-
-<script type="text/javascript">
-                      $.timeoutDialog({
-                                         timeout: 900,
-                                         countdown:120,
-                                         keep_alive_url: '/keep-alive',
-                                         logout_url: '/marriage-allowance-application/logout'
-                                        });
-
-</script>
-
-<script type="text/javascript" id="webchat" data-webchat-id="@config.ApplicationConfig.webchatId">var EG_ACT_ID="@config.ApplicationConfig.webchatId"; (function(e,f){var d,c,b,a=e.createElement("iframe");a.src="about:blank";a.title="";a.id="egot_iframe";(a.frameElement||a).style.cssText="width:0;height:0;border:0";b=e.getElementsByTagName("script");b=b[b.length-1];b.parentNode.insertBefore(a,b);try
-            {c=a.contentWindow.document}
-            catch(g)
-            {d=e.domain,a.src="javascript:var d=document.open();d.domain='"+d+"';void(0);",c=a.contentWindow.document}
-                c.open()._d=function()
-                {var a=this.createElement("script");d&&(this.domain=d);a.src=f;this.isEGFIF= !0;this.body.appendChild(a)}
-                ;c.write('<body onload="document._d();">');c.close()})(document,"//analytics.analytics-egain.com/onetag/"+EG_ACT_ID);
-
-</script>
+ <script type="text/javascript" id="webchat" data-webchat-id="@config.ApplicationConfig.webchatId">
+  var EG_ACT_ID="@config.ApplicationConfig.webchatId"; (function(e,f){var d,c,b,a=e.createElement("iframe");a.src="about:blank";a.title="";a.id="egot_iframe";(a.frameElement||a).style.cssText="width:0;height:0;border:0";b=e.getElementsByTagName("script");b=b[b.length-1];b.parentNode.insertBefore(a,b);try
+             {c=a.contentWindow.document}
+             catch(g)
+             {d=e.domain,a.src="javascript:var d=document.open();d.domain='"+d+"';void(0);",c=a.contentWindow.document}
+                 c.open()._d=function()
+                 {var a=this.createElement("script");d&&(this.domain=d);a.src=f;this.isEGFIF= !0;this.body.appendChild(a)}
+                 ;c.write('<body onload="document._d();">');c.close()})(document,"//analytics.analytics-egain.com/onetag/"+EG_ACT_ID);
+ </script>
 }
 
 
 @isWelsh = @{
-if(messages.lang.code == "cy"){
-true
+ messages.lang.code == "cy"
 }
-else {
-false
-}
-}
+
 @getHelpForm = {
-@includes.report_problem(supportLinkEnabled, formPartialRetriever, appConfig)
+ @includes.report_problem(supportLinkEnabled, formPartialRetriever, appConfig)
 }
 
 @commonContentHeader = {
-
-@if(ApplicationConfig.isWelshEnabled) {
-@langSwitch
-}
+ @if(ApplicationConfig.isWelshEnabled) {
+  @langSwitch
+ }
 }
 
 @if(ApplicationConfig.enableRefresh) {
@@ -114,21 +115,21 @@ false
 @isUserResearchBannerHidden = @{request.cookies.exists((x: Cookie) => x.name == "mdtpurr")}
 
 @mustacheCheck(str: String) = @{
-if(str.trim=="") false else str
+ if(str.trim=="") false else str
 }
 
 @sidebar = {
-@if(sidebarLinks.isDefined) {
-@layouts.sidebar(sidebarLinks.get, sidebarClass)
-}
+ @if(sidebarLinks.isDefined) {
+  @layouts.sidebar(sidebarLinks.get, sidebarClass)
+ }
 }
 
 @titleName = @{
-if(request.authState.permanent) {
-appConfig.pageTitle
-} else {
-""
-}
+ if(request.authState.permanent) {
+  appConfig.pageTitle
+ } else {
+  ""
+ }
 }
 
 @* user.fold(HtmlFormat.empty) {
@@ -139,76 +140,74 @@ appConfig.pageTitle
 *}
 *@
 @actingAttorneyBanner = @{
-HtmlFormat.empty
+ HtmlFormat.empty
 }
 
 @googleAnalytics = @{
-Map[String, Any](
-"trackingId" -> ApplicationConfig.analyticsToken,
-"cookieDomain" -> ApplicationConfig.analyticsHost,
-"confidenceLevel" -> request.confidenceLevel.fold(false)(_.toString),
-"authProvider" -> request.authProvider
-) ++ gaDimensions.getOrElse(Map.empty)
+ Map[String, Any](
+  "trackingId" -> ApplicationConfig.analyticsToken,
+  "cookieDomain" -> ApplicationConfig.analyticsHost,
+  "confidenceLevel" -> request.confidenceLevel.fold(false)(_.toString),
+  "authProvider" -> request.authProvider
+ ) ++ gaDimensions.getOrElse(Map.empty)
 }
 
 @{
 
-val arguments = Map[String, Any](
-"pageTitle" -> s"$title",
-"linkElems" -> Map(
-"url" -> routes.Assets.at("stylesheets/tamc.css")
-),
-"hasNavLinks" -> true,
-"navTitle" -> titleName,
-"removeServiceInfo" -> false,
+ val arguments = Map[String, Any](
+  "pageTitle" -> s"$title",
+  "linkElems" -> Map(
+   "url" -> routes.Assets.at("stylesheets/tamc.css")
+  ),
+  "hasNavLinks" -> true,
+  "navTitle" -> titleName,
+  "removeServiceInfo" -> false,
 
-"betaBanner" -> true,
-"feedbackIdentifier" -> appConfig.contactFormServiceIdentifier,
-"includeHMRCBranding" -> true,
+  "betaBanner" -> true,
+  "feedbackIdentifier" -> appConfig.contactFormServiceIdentifier,
+  "includeHMRCBranding" -> true,
 
-"hideAccountMenu" -> !request.authState.permanent,
-"assetsPath" -> appConfig.assetsPrefix,
+  "hideAccountMenu" -> !request.authState.permanent,
+  "assetsPath" -> appConfig.assetsPrefix,
 
-"isGovernmentGateway" -> request.authProvider.contains("GovernmentGateway"),
-"isVerify" -> request.authProvider.contains("Verify"),
-"isSa" -> request.isSA,
-"signOutUrl" -> (if(request.authState.isLoggedIn) Some(routes.AuthorisationController.logout()) else None),
+  "isGovernmentGateway" -> request.authProvider.contains("GovernmentGateway"),
+  "isVerify" -> request.authProvider.contains("Verify"),
+  "isSa" -> request.isSA,
+  "signOutUrl" -> (if(request.authState.isLoggedIn) Some(routes.AuthorisationController.logout()) else None),
 
-"actingAttorneyBanner" -> actingAttorneyBanner,
-"mainContentHeader" -> commonContentHeader,
-"sidebar" -> sidebar,
-"getHelpForm" -> getHelpForm,
-"googleAnalytics" -> googleAnalytics,
+  "actingAttorneyBanner" -> actingAttorneyBanner,
+  "mainContentHeader" -> commonContentHeader,
+  "sidebar" -> sidebar,
+  "getHelpForm" -> getHelpForm,
+  "googleAnalytics" -> googleAnalytics,
 
-"scriptElems" -> Seq(
-Map("url" -> routes.Assets.at("javascripts/tamc.js")),
-Map("url" -> routes.Assets.at("javascripts/banner_close.js"))
-),
+  "scriptElems" -> Seq(
+   Map("url" -> routes.Assets.at("javascripts/tamc.js")),
+   Map("url" -> routes.Assets.at("javascripts/banner_close.js"))
+  ),
 
-"mainAttributes" -> mainConfig.maybeMainDataAttributes,
-"inlineScript" -> scriptElement,
-"mainClass" -> mainConfig,
-"isWelsh" -> isWelsh,
-"optimizelyProjectId"  -> "8421482974",
-"showPropositionLinks" -> true,
-"langSelector" -> {
-Map("enUrl" -> controllers.routes.LanguageController.enGb(),
-"cyUrl" -> controllers.routes.LanguageController.cyGb())
-}
-)
+  "mainAttributes" -> mainConfig.maybeMainDataAttributes,
+  "inlineScript" -> scriptElement,
+  "mainClass" -> mainConfig,
+  "isWelsh" -> isWelsh,
+  "optimizelyProjectId"  -> "8421482974",
+  "showPropositionLinks" -> true,
+  "langSelector" -> langSelectorMap
+ )
 
-val templateArguments = {
-if(!isUserResearchBannerHidden && ApplicationConfig.urBannerEnabled) {
-arguments ++ Map[String, Any](
-"fullWidthBannerTitle" -> Messages("tamc.banner.recruitment.title"),
-"fullWidthBannerText" -> Messages("tamc.banner.recruitment.link"),
-"fullWidthBannerLink" -> Messages("tamc.banner.recruitment.linkURL"),
-"fullWidthBannerDismissText" -> Messages("tamc.banner.recruitment.reject"),
-"fullWidthBannerGaAction" -> "homepage UR banner:Help improve digital services by joining the HMRC user panel (opens in new window)"
-)
-} else arguments
-}
+ val templateArguments = {
+  if(!isUserResearchBannerHidden && ApplicationConfig.urBannerEnabled) {
+   arguments ++ Map[String, Any](
+    "fullWidthBannerTitle" -> Messages("tamc.banner.recruitment.title"),
+    "fullWidthBannerText" -> Messages("tamc.banner.recruitment.link"),
+    "fullWidthBannerLink" -> Messages("tamc.banner.recruitment.linkURL"),
+    "fullWidthBannerDismissText" -> Messages("tamc.banner.recruitment.reject"),
+    "fullWidthBannerGaAction" -> "homepage UR banner:Help improve digital services by joining the HMRC user panel (opens in new window)"
+   )
+  } else arguments
+ }
 
-templateRenderer.renderDefaultTemplate(appConfig.frontendTemplatePath, layouts.article(mainContent, false, None), templateArguments)
+ templateRenderer.renderDefaultTemplate(appConfig.frontendTemplatePath, layouts.article(mainContent, false, None), templateArguments)
+
 }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -31,6 +31,8 @@ GET    /you-cannot-use-this-service                @controllers.TransferControll
 
 #Change of Circumstances
 GET    /history                                    @controllers.UpdateRelationshipController.history
+GET    /history-en                                 @controllers.UpdateRelationshipController.historyWithEn
+GET    /history-cy                                 @controllers.UpdateRelationshipController.historyWithCy
 POST   /make-changes                               @controllers.UpdateRelationshipController.makeChange
 GET    /change-of-income                           @controllers.UpdateRelationshipController.changeOfIncome
 GET    /bereavement                                @controllers.UpdateRelationshipController.bereavement

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -17,6 +17,8 @@ POST   /benefit-calculator-pta                     @controllers.EligibilityContr
 GET    /transfer-allowance                         @controllers.TransferController.transfer
 POST   /transfer-allowance                         @controllers.TransferController.transferAction
 GET    /date-of-marriage                           @controllers.TransferController.dateOfMarriage
+GET    /date-of-marriage-en                        @controllers.TransferController.dateOfMarriageWithEn
+GET    /date-of-marriage-cy                        @controllers.TransferController.dateOfMarriageWithCy
 POST   /date-of-marriage                           @controllers.TransferController.dateOfMarriageAction
 GET    /eligible-years                             @controllers.TransferController.eligibleYears
 POST   /eligible-years                             @controllers.TransferController.eligibleYearsAction

--- a/test/controllers/TransferControllerTest.scala
+++ b/test/controllers/TransferControllerTest.scala
@@ -25,6 +25,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{CachingService, TimeService, TransferService}
@@ -38,6 +39,10 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.partials.FormPartialRetriever
 import uk.gov.hmrc.renderer.TemplateRenderer
 import uk.gov.hmrc.time
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class TransferControllerTest extends ControllerBaseSpec {
 
@@ -81,6 +86,28 @@ class TransferControllerTest extends ControllerBaseSpec {
     "return success" in {
       val result = controller().dateOfMarriage()(request)
       status(result) shouldBe OK
+    }
+  }
+
+  "dateOfMarriageWithCy" should {
+    "redirect to dateOfMarriage, with a welsh language setting" in {
+      val result = controller().dateOfMarriageWithCy()(request)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.TransferController.dateOfMarriage().url)
+      val resolved = Await.result(result, 5 seconds)
+      resolved.header.headers.keys should contain("Set-Cookie")
+      resolved.header.headers("Set-Cookie") should include("PLAY_LANG=cy")
+    }
+  }
+
+  "dateOfMarriageWithEn" should {
+    "redirect to dateOfMarriage, with an english language setting" in {
+      val result = controller().dateOfMarriageWithEn()(request)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.TransferController.dateOfMarriage().url)
+      val resolved = Await.result(result, 5 seconds)
+      resolved.header.headers.keys should contain("Set-Cookie")
+      resolved.header.headers("Set-Cookie") should include("PLAY_LANG=en")
     }
   }
 

--- a/test/controllers/UpdateRelationshipControllerTest.scala
+++ b/test/controllers/UpdateRelationshipControllerTest.scala
@@ -40,7 +40,9 @@ import uk.gov.hmrc.play.partials.FormPartialRetriever
 import uk.gov.hmrc.renderer.TemplateRenderer
 import uk.gov.hmrc.time
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class UpdateRelationshipControllerTest extends ControllerBaseSpec {
 
@@ -108,6 +110,28 @@ class UpdateRelationshipControllerTest extends ControllerBaseSpec {
         val result: Future[Result] = controller().history()(request)
         status(result) shouldBe OK
       }
+    }
+  }
+
+  "historyWithCy" should {
+    "redirect to history, with a welsh language setting" in {
+      val result: Future[Result] = controller(instanceOf[MockTemporaryAuthenticatedAction]).historyWithCy()(request)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.UpdateRelationshipController.history().url)
+      val resolved = Await.result(result, 5 seconds)
+      resolved.header.headers.keys should contain("Set-Cookie")
+      resolved.header.headers("Set-Cookie") should include("PLAY_LANG=cy")
+    }
+  }
+
+  "historyWithEn" should {
+    "redirect to history, with an english language setting" in {
+      val result: Future[Result] = controller(instanceOf[MockTemporaryAuthenticatedAction]).historyWithEn()(request)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.UpdateRelationshipController.history().url)
+      val resolved = Await.result(result, 5 seconds)
+      resolved.header.headers.keys should contain("Set-Cookie")
+      resolved.header.headers("Set-Cookie") should include("PLAY_LANG=en")
     }
   }
 


### PR DESCRIPTION
Introduce dedicated Play HTTP endpoints for loading with fixed language setting.
Welsh toggle workaround for pages in each of the eligibility and history journeys, which use HTTP POST (and otherwise fail when switching to welsh).