### PR TITLE
DDCNOS-532: filters nulls when bind email

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This service provides the frontend endpoint for the [Marriage Allowance project]
 Summary
 ------------
 
-This service allow a customer to apply for apply for Marriage Allowance as we as to modify existing Marriage Allowance application.
+This service allow a customer to apply for Marriage Allowance as we as to modify existing Marriage Allowance application.
 
 Tax rates
 ------------
 The service should now dynamically pick the tax year from the current system date. The tax year rates must be updated every tax year before 6 April in [conf/data/tax-rates.conf] file to pick the new tax rates.
-If the rates are not updated it will take consider zero (0) for all the fields from tax-rates files
+If the rates are not updated it will take consider zero (0) for all the fields from tax-rates files.
 
 
 Requirements

--- a/app/uk/gov/hmrc/emailaddress/PlayFormFormatter.scala
+++ b/app/uk/gov/hmrc/emailaddress/PlayFormFormatter.scala
@@ -32,9 +32,11 @@ object PlayFormFormatter {
       def unbind(key: String, value: String): Map[String, String] = Map(key -> value)
 
       def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] = {
-        data.get(key).map {
-          _.trim
-        }.filterNot(_.isEmpty()).toRight(Seq(FormError(key, error)))
+        data.get(key)
+          .filterNot(_ == null)
+          .map(_.trim)
+          .filterNot(_.isEmpty())
+          .toRight(Seq(FormError(key, error)))
       }
     })
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
-   "uk.gov.hmrc" %% "emailaddress" % "3.2.0",
+   "uk.gov.hmrc" %% "emailaddress" % "3.4.0",
     "uk.gov.hmrc" %% "frontend-bootstrap" % "12.9.0",
     "com.ibm.icu" % "icu4j" % "54.1.1",
     "uk.gov.hmrc" %% "http-caching-client" % "8.4.0-play-25",

--- a/test/controllers/ContentTest.scala
+++ b/test/controllers/ContentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import _root_.services.{CachingService, TimeService, TransferService}
 import config.ApplicationConfig._
 import controllers.actions.AuthenticatedActionRefiner
 import models._
-import org.joda.time.LocalDate
+import org.joda.time.{DateTimeFieldType, LocalDate}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
@@ -447,10 +447,11 @@ class ContentTest extends ControllerBaseSpec {
     }
 
     "display form error message (date of marriage is after today’s date)" in {
+      val localDate = LocalDate.now().plusYears(1)
       val request = FakeRequest().withFormUrlEncodedBody(
-        "dateOfMarriage.day" -> "1",
-        "dateOfMarriage.month" -> "1",
-        "dateOfMarriage.year" -> "2020"
+        "dateOfMarriage.day" -> localDate.getDayOfMonth.toString,
+        "dateOfMarriage.month" -> localDate.getMonthOfYear.toString,
+        "dateOfMarriage.year" -> localDate.getYear.toString
       )
       val result = transferController.dateOfMarriageAction(request)
 

--- a/test/controllers/ContentTest.scala
+++ b/test/controllers/ContentTest.scala
@@ -627,8 +627,8 @@ class ContentTest extends ControllerBaseSpec {
       form shouldNot be(null)
       val labelName = form.select("label[for=transferor-email]").first()
       labelName.getElementsByClass("error-message").first() shouldNot be(null)
-      labelName.getElementsByClass("error-message").first().text() shouldBe "Enter an email address with a name, @ symbol and a domain name, like yourname@example.com"
-      document.getElementById("transferor-email-error").text() shouldBe "Enter an email address with a name, @ symbol and a domain name, like yourname@example.com"
+      labelName.getElementsByClass("error-message").first().text() shouldBe "Your email address must only include letters a to z, numbers 0 to 9, full stops, hyphens and underscores"
+      document.getElementById("transferor-email-error").text() shouldBe "Your email address must only include letters a to z, numbers 0 to 9, full stops, hyphens and underscores"
     }
 
     "display form error message (transferor email does not include TLD)" in {

--- a/test/forms/EmailFormTest.scala
+++ b/test/forms/EmailFormTest.scala
@@ -21,14 +21,15 @@ import java.util.Locale
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.FormError
-import play.api.i18n.{I18nSupport, Lang, MessagesApi}
+import play.api.i18n.{I18nSupport, Lang, Messages, MessagesApi}
 import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.play.test.UnitSpec
 
 class EmailFormTest extends UnitSpec with I18nSupport with GuiceOneAppPerSuite with MockitoSugar {
 
   implicit def messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
-  val messages = messagesApi.preferred(Seq(Lang(Locale.ENGLISH)))
+
+  val messages: Messages = messagesApi.preferred(Seq(Lang(Locale.ENGLISH)))
 
   ".email" should {
     "bind a valid email address" in {
@@ -37,6 +38,22 @@ class EmailFormTest extends UnitSpec with I18nSupport with GuiceOneAppPerSuite w
       )
       val res = EmailForm.emailForm.mapping.bind(formInput)
       res shouldBe Right(new EmailAddress("example@email.com"))
+    }
+
+    "bind a valid email address2" in {
+      val formInput = Map[String, String](
+        "transferor-email" -> "example@c.email.com"
+      )
+      val res = EmailForm.emailForm.mapping.bind(formInput)
+      res shouldBe Right(new EmailAddress("example@c.email.com"))
+    }
+
+    "bind a valid email address3" in {
+      val formInput = Map[String, String](
+        "transferor-email" -> "example.c@email.com"
+      )
+      val res = EmailForm.emailForm.mapping.bind(formInput)
+      res shouldBe Right(new EmailAddress("example.c@email.com"))
     }
 
     "fail to bind, with a specific valid character failure for am email address containing invalid characters" in {

--- a/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
+++ b/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
@@ -29,7 +29,7 @@ object EmailAddressGenerators {
     for (_ <- 1 to index) {
       val mailbox = randomString(1)
       val domain = randomString(2)
-      res += s"$mailbox@$domain".mkString
+      res += s"$mailbox@$domain"
     }
     res.toList
   }

--- a/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
+++ b/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
@@ -16,21 +16,38 @@
 
 package uk.gov.hmrc.emailaddress
 
-import org.scalacheck.Gen._
+import scala.collection.mutable.ListBuffer
+import scala.util.Random
 
-trait EmailAddressGenerators {
+object EmailAddressGenerators {
 
-  val nonEmptyString = nonEmptyListOf(alphaChar).map(_.mkString)
+  lazy val random: Random = new Random()
 
-  val validMailbox = nonEmptyString
+  def randomEmailAddresses(): List[String] = {
+    var res = ListBuffer[String]()
+    val index = newIndex
+    for (_ <- 1 to index) {
+      val mailbox = randomString(1)
+      val domain = randomString(2)
+      res += s"$mailbox@$domain".mkString
+    }
+    res.toList
+  }
 
-  val validDomain = for {
-    topLevelDomain <- nonEmptyString
-    otherParts <- listOf(nonEmptyString)
-  } yield (otherParts :+ topLevelDomain).mkString
+  private def randomString(dotsNumber: Int): String = {
+    var result = ""
+    for (i <- 1 to dotsNumber) {
+      val index = newIndex
+      val res = random.alphanumeric.take(index).filter(!_.isDigit).mkString.toLowerCase
+      if (i >= dotsNumber) {
+        result += res
+      } else {
+        result += res + "."
+      }
+    }
 
-  val validEmailAddresses = for {
-    mailbox <- validMailbox
-    domain <- validDomain
-  } yield s"$mailbox@$domain"
+    result
+  }
+
+  private def newIndex: Int = random.nextInt(10) + 5
 }

--- a/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
+++ b/test/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.emailaddress
 
-import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
 object EmailAddressGenerators {
@@ -24,29 +23,22 @@ object EmailAddressGenerators {
   lazy val random: Random = new Random()
 
   def randomEmailAddresses(): List[String] = {
-    var res = ListBuffer[String]()
     val index = newIndex
-    for (_ <- 1 to index) {
+    for (_ <- List.range(1, index)) yield {
       val mailbox = randomString(1)
       val domain = randomString(2)
-      res += s"$mailbox@$domain"
+      s"$mailbox@$domain"
     }
-    res.toList
   }
 
   private def randomString(dotsNumber: Int): String = {
-    var result = ""
-    for (i <- 1 to dotsNumber) {
+    val result = for (_ <- List.range(0, dotsNumber)) yield {
       val index = newIndex
       val res = random.alphanumeric.take(index).filter(!_.isDigit).mkString.toLowerCase
-      if (i >= dotsNumber) {
-        result += res
-      } else {
-        result += res + "."
-      }
+      res
     }
 
-    result
+    result.mkString(".")
   }
 
   private def newIndex: Int = random.nextInt(10) + 5

--- a/test/uk/gov/hmrc/emailaddress/PlayFormFormatterSpec.scala
+++ b/test/uk/gov/hmrc/emailaddress/PlayFormFormatterSpec.scala
@@ -21,18 +21,32 @@ import org.scalatest.{Matchers, WordSpec}
 import play.api.data.FormError
 import play.api.data.Forms.optional
 
-class PlayFormFormatterSpec extends WordSpec with Matchers with PropertyChecks with EmailAddressGenerators {
+class PlayFormFormatterSpec extends WordSpec with Matchers with PropertyChecks {
+
+  val emails: List[String] = EmailAddressGenerators.randomEmailAddresses().distinct
 
   "PlayFormFormatter.emailAddress mapping" should {
 
-    "accept valid emails" in forAll(validEmailAddresses) {
-      address =>
-        emailAddressMapping.bind(Map("email" -> address)).right.get shouldBe EmailAddress(address)
+    "emails should not be empty" in {
+      assert(emails.nonEmpty)
     }
 
-    "accept valid emails with padding" in forAll(validEmailAddresses) {
-      address =>
-        emailAddressMapping.bind(Map("email" -> s" ${address} ")).right.get shouldBe EmailAddress(address)
+    emails foreach { email =>
+      s"$email map in EmailAddress with success" in {
+        EmailAddress(email).isInstanceOf[EmailAddress]
+      }
+    }
+
+    emails foreach { email =>
+      s"$email accept valid emails" in {
+        emailAddressMapping.bind(Map("email" -> email)).right.get shouldBe EmailAddress(email)
+      }
+    }
+
+    emails foreach { email =>
+      s"$email accept valid emails with padding" in {
+        emailAddressMapping.bind(Map("email" -> s" $email ")).right.get shouldBe EmailAddress(email)
+      }
     }
 
     "reject missing or empty field" in {
@@ -50,19 +64,19 @@ class PlayFormFormatterSpec extends WordSpec with Matchers with PropertyChecks w
     "allow optional emailAddress mapping" in {
       optionalEmailAddressMapping.bind(data = Map()).right.get shouldBe None
       optionalEmailAddressMapping.bind(data = Map("email" -> "")).right.get shouldBe None
-      optionalEmailAddressMapping.bind(data = Map("email" -> "example@example")).right.get shouldBe Some(EmailAddress("example@example"))
+      optionalEmailAddressMapping.bind(data = Map("email" -> "example@example.com")).right.get shouldBe Some(EmailAddress("example@example.com"))
     }
 
-    "reject invalid email" in {
-      invalidEmailInputData.foreach(
-        address =>
-          emailAddressMapping.bind(data = address).left.get shouldBe List(FormError("email", List("error.email"), List())))
+    invalidEmailInputData foreach { email =>
+      s"$email reject invalid email" in {
+        emailAddressMapping.bind(data = email).left.get shouldBe List(FormError("email", List("error.email"), List()))
+      }
     }
 
-    "reject invalid email (using custom error message)" in {
-      invalidEmailInputData.foreach(
-        address =>
-          emailAddressCustomErrorsMapping.bind(data = address).left.get shouldBe List(FormError("email", List("field.invalid"), List())))
+    invalidEmailInputData foreach { email =>
+      s"$email reject invalid email (using custom error message)" in {
+        emailAddressCustomErrorsMapping.bind(data = email).left.get shouldBe List(FormError("email", List("field.invalid"), List()))
+      }
     }
 
     "reject too long email address (when using 'emailMaxLength' constraint)" in {
@@ -82,58 +96,76 @@ class PlayFormFormatterSpec extends WordSpec with Matchers with PropertyChecks w
     "reject email address which does not match given regex" in {
       val errors: Seq[FormError] = emailAddressMapping.verifying {
         patternConstraint
-      }.bind(Map("email" -> "example@example")).left.get
+      }.bind(Map("email" -> "example@example.com-asd")).left.get
       errors.size shouldBe 1
       val headError = errors.head
       headError.key shouldBe "email"
       headError.messages.size shouldBe 1
       headError.messages.head shouldBe "error.pattern"
       headError.args.size shouldBe 1
-      headError.args.head.toString() shouldBe """(.+)(\.[a-zA-Z0-9-]*)$"""
+      headError.args.head.toString shouldBe """(.+)(\.[a-zA-Z0-9-]*)(^[\.])$"""
     }
 
     "reject email address which does not match given regex (with custom error)" in {
       val errors: Seq[FormError] = emailAddressMapping.verifying {
         patternConstraintWithError
-      }.bind(Map("email" -> "example@example")).left.get
+      }.bind(Map("email" -> "example@example.com-asd")).left.get
       errors.size shouldBe 1
       val headError = errors.head
       headError.key shouldBe "email"
       headError.messages.size shouldBe 1
       headError.messages.head shouldBe "field.pattern"
       headError.args.size shouldBe 1
-      headError.args.head.toString() shouldBe """(.+)(\.[a-zA-Z0-9-]*)$"""
+      headError.args.head.toString shouldBe """(.+)(\.[a-zA-Z0-9-]*)(^[\.])$"""
     }
   }
 
-  def emailAddressMapping =
+  private def emptyEmailInputData: Seq[Map[String, String]] =
+    Seq(
+      Map(),
+      Map("email" -> null),
+      Map("email" -> ""),
+      Map("email" -> " "),
+      Map("email" -> "        "),
+      Map("email" -> "\t\t\t\t")
+    )
+
+  private def invalidEmailInputData: Seq[Map[String, String]] =
+    Seq(
+      Map("email" -> "test"),
+      Map("email" -> "test@"),
+      Map("email" -> "@test"),
+      Map("email" -> "test@test"),
+      Map("email" -> "a@b"),
+      Map("email" -> "test@example.comtest@example.com"),
+      Map("email" -> "test@example..com"),
+      Map("email" -> "test@example...com"),
+      Map("email" -> "test@example....com"),
+      Map("email" -> "test@example com")
+    )
+
+  private def emailAddressMapping =
     PlayFormFormatter.emailAddress.withPrefix("email")
 
-  def emailAddressCustomErrorsMapping =
+  private def emailAddressCustomErrorsMapping =
     PlayFormFormatter.emailAddress(errorRequired = "field.required", errorEmail = "field.invalid").withPrefix("email")
 
-  def maxLengthConstraint =
+  private def maxLengthConstraint =
     PlayFormFormatter.emailMaxLength(maxLength = 10)
 
-  def maxLengthConstraintWithError =
+  private def maxLengthConstraintWithError =
     PlayFormFormatter.emailMaxLength(maxLength = 10, error = "field.exceeds")
 
-  def optionalEmailAddressMapping =
+  private def optionalEmailAddressMapping =
     optional[EmailAddress](PlayFormFormatter.emailAddress.withPrefix("email"))
 
-  def patternConstraint = {
-    val HAS_TLD = """(.+)(\.[a-zA-Z0-9-]*)$""".r
+  private def patternConstraint = {
+    val HAS_TLD = """(.+)(\.[a-zA-Z0-9-]*)(^[\.])$""".r
     PlayFormFormatter.emailPattern(HAS_TLD)
   }
 
-  def patternConstraintWithError = {
-    val HAS_TLD = """(.+)(\.[a-zA-Z0-9-]*)$""".r
+  private def patternConstraintWithError = {
+    val HAS_TLD = """(.+)(\.[a-zA-Z0-9-]*)(^[\.])$""".r
     PlayFormFormatter.emailPattern(HAS_TLD, error = "field.pattern")
   }
-
-  def emptyEmailInputData: Seq[Map[String, String]] =
-    Seq(Map(), Map("email" -> ""), Map("email" -> " "))
-
-  def invalidEmailInputData: Seq[Map[String, String]] =
-    Seq(Map("email" -> "test"), Map("email" -> "test@"), Map("email" -> "@test"), Map("email" -> "test@example.comtest@example.com"))
 }


### PR DESCRIPTION
bump email address library lib include new fixes to validate email address
update tamc-frontend per this library update to combine all cases
rewrite random email generator for easier prediction of how it will generate
rewrite and add some tests related to email changes
add and check ticket related email addresses as it accept them